### PR TITLE
Pre-season mode: draft-prep board (all players, not roster-scoped)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the branching model
 - `refactored/`: **This is the real application.** `refactored/api.py` is the
   entrypoint (`CMD` in the `Dockerfile`) — a stdlib WSGI server exposing
   `/health`, `/projections`, `/lineup`, `/lineup/diffs`, `/defenses`,
-  `/player/odds`, `/defense/odds`, and `/dashboard`, and serving the UI under
-  `/` and `/ui/*`. See `refactored/services.py` for the orchestration layer,
-  `refactored/range_model.py` + `refactored/prob_models.py` for how
-  betting-line probabilities become floor/mid/ceiling fantasy point ranges,
-  `refactored/aggregator.py` + `refactored/planner.py` for how odds are
-  fetched/grouped, and `refactored/odds_client.py` + `refactored/ratelimit.py`
-  for caching and Odds-API rate-limit tracking.
+  `/draft-board`, `/player/odds`, `/defense/odds`, and `/dashboard`, and
+  serving the UI under `/` and `/ui/*`. See `refactored/services.py` for the
+  orchestration layer, `refactored/range_model.py` + `refactored/prob_models.py`
+  for how betting-line probabilities become floor/mid/ceiling fantasy point
+  ranges, `refactored/aggregator.py` + `refactored/planner.py` for how odds
+  are fetched/grouped for your roster, `refactored/draft_prep.py` for the
+  same thing but for every player league-wide (pre-draft, before you have a
+  roster to scope to), and `refactored/odds_client.py` +
+  `refactored/ratelimit.py` for caching and Odds-API rate-limit tracking.
 - `config.py`: Loads environment configuration and defines shared constants
   (position→market mappings, Sleeper↔Odds-API name/team mappings, scoring
   key mappings).

--- a/refactored/api.py
+++ b/refactored/api.py
@@ -19,7 +19,7 @@ from typing import Callable
 
 from . import ratelimit
 from . import services  # for detail endpoints
-from .services import compute_projections, compute_book_coverage, build_lineup, build_lineup_diffs, list_defenses, build_dashboard
+from .services import compute_projections, compute_book_coverage, build_lineup, build_lineup_diffs, list_defenses, build_dashboard, compute_draft_board
 
 # Module-level debug flag (defaults to False). Can be enabled via --debug CLI.
 _DEBUG_FLAG = False
@@ -232,6 +232,22 @@ def application(environ, start_response):
             _dprint(f"[api] defense/odds done games={len(data.get('games', []))} dt={(time.time()-t0):.2f}s")
             return _json_response(start_response, "200 OK", data)
 
+        if path == "/draft-board":
+            username = q("username", "wesnicol")
+            season = q("season", "2025")
+            week = q("week", "this")
+            region = q("region", "us")
+            model = q("model", "const")
+            fresh = q("fresh", "0") in ("1", "true", "True")
+            mode = q("mode", "auto")
+            positions_raw = q("positions", "")
+            positions = [p.strip().upper() for p in positions_raw.split(",") if p.strip()] or None
+            t0 = time.time()
+            _dprint(f"[api] draft-board season={season} week={week} region={region} mode={mode} model={model} fresh={fresh} positions={positions}")
+            data = compute_draft_board(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, positions=positions)
+            _dprint(f"[api] draft-board done players={len(data.get('players', []))} dt={(time.time()-t0):.2f}s")
+            return _json_response(start_response, "200 OK", data)
+
         if path == "/dashboard":
             username = q("username", "wesnicol")
             season = q("season", "2025")
@@ -281,6 +297,7 @@ Endpoints:
   GET /lineup?username=&season=&week=this|next&target=mid|floor|ceiling&fresh=0|1
   GET /lineup/diffs?username=&season=&week=this|next&fresh=0|1
   GET /defenses?username=&season=&week=this|next&scope=owned|available|both&fresh=0|1
+  GET /draft-board?username=&season=&week=this|next&positions=QB,RB,WR,TE&fresh=0|1
 """)
     class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
         daemon_threads = True

--- a/refactored/draft_prep.py
+++ b/refactored/draft_prep.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import sleeper_api
+from config import SLEEPER_TO_ODDSAPI_TEAM, SLEEPER_ODDS_API_PLAYER_NAME_MAPPING
+from .planner import PlannedGame
+from .weekly_windows import compute_week_windows, in_window
+from . import odds_client
+
+# Draft prep only covers positions the rest of the app already knows how to
+# turn into fantasy points (see PRIMARY_MARKET_WHITELIST in range_model.py).
+# Kickers/DEF aren't included here for the same reason they're excluded from
+# build_lineup: no player-level market signal for K, and DEF value doesn't
+# come from a per-player prop line at all (see list_defenses instead).
+DRAFT_POSITIONS = ("QB", "RB", "WR", "TE")
+
+# Conservative market set (no "_alternate" markets) to keep a draft-board
+# refresh from ballooning into dozens of extra Odds API requests per game --
+# see CONTRIBUTING.md's "Odds API quota awareness" section. The lognormal/
+# Poisson single-line fallback in range_model.py makes a single main line a
+# reasonable basis for floor/mid/ceiling, so this is a real cost/accuracy
+# tradeoff, not just a shortcut.
+CORE_DRAFT_MARKETS = (
+    "player_anytime_td",
+    "player_receptions",
+    "player_reception_yds",
+    "player_rush_yds",
+    "player_pass_yds",
+    "player_pass_tds",
+    "player_pass_interceptions",
+)
+
+
+def _all_active_players_by_team() -> Dict[str, List[dict]]:
+    """Sleeper's full player DB, filtered to skill positions and grouped by
+    Odds-API-style full team name. Unlike planner.py, this is NOT scoped to
+    any single roster -- that's the entire point of draft prep.
+
+    A player is included if Sleeper currently has them assigned to an NFL
+    team (Sleeper clears `team` for free agents/retired players). This will
+    include bench/practice-squad depth along with starters, which is fine --
+    a draft board is supposed to be broad.
+    """
+    all_players = sleeper_api.get_players()
+    by_team: Dict[str, List[dict]] = {}
+    for pdata in all_players.values():
+        pos = pdata.get("position")
+        if pos not in DRAFT_POSITIONS:
+            continue
+        team_abbr = pdata.get("team")
+        if not team_abbr:
+            continue
+        full_team = SLEEPER_TO_ODDSAPI_TEAM.get(team_abbr)
+        if not full_team:
+            continue
+        full_name = pdata.get("full_name")
+        if not full_name:
+            continue
+        alias = SLEEPER_ODDS_API_PLAYER_NAME_MAPPING.get(full_name, full_name)
+        by_team.setdefault(full_team, []).append({
+            "full_name": full_name,
+            "alias": alias,
+            "primary_position": pos,
+            "editorial_team_full_name": full_team,
+        })
+    return by_team
+
+
+def plan_week_for_draft(week: str = "this", regions: str = "us", cache_mode: str = "auto") -> Dict[str, PlannedGame]:
+    """Like planner.plan_relevant_games_and_markets, but for every active
+    skill player on every team playing in the target week -- not just one
+    roster. Returns game_id -> PlannedGame for the requested window only.
+    """
+    (this_start, this_end), (next_start, next_end) = compute_week_windows()
+    start, end = (this_start, this_end) if week == "this" else (next_start, next_end)
+
+    events = odds_client.get_nfl_events(regions=regions, mode=cache_mode)
+    by_team = _all_active_players_by_team()
+
+    plan: Dict[str, PlannedGame] = {}
+    for e in events:
+        ts = e.get("commence_time")
+        if not ts or not in_window(ts, (start, end)):
+            continue
+        home, away = e.get("home_team"), e.get("away_team")
+        players = list(by_team.get(home, [])) + list(by_team.get(away, []))
+        if not players:
+            continue
+        plan[e["id"]] = PlannedGame(
+            game_id=e["id"],
+            home_team=home,
+            away_team=away,
+            commence_time=ts,
+            players=players,
+            markets=list(CORE_DRAFT_MARKETS),
+        )
+    return plan

--- a/refactored/services.py
+++ b/refactored/services.py
@@ -14,6 +14,7 @@ from .aggregator import aggregate_by_week
 from .range_model import compute_fantasy_range, compute_defense_fantasy_range
 from . import odds_client
 from . import ratelimit
+from . import draft_prep
 from config import SLEEPER_TO_ODDSAPI_TEAM
 from predicted_stats import predict_stats_for_player
 from config import STAT_MARKET_MAPPING_SLEEPER, POSITION_STAT_CONFIG
@@ -461,6 +462,79 @@ def compute_projections(username: str, season: str, week: str = "this", region: 
     # store in cache
     _proj_cache[key] = (now, payload)
     compute_projections._cache = _proj_cache
+    return payload
+
+
+def compute_draft_board(
+    username: str,
+    season: str,
+    week: str = "this",
+    region: str = "us",
+    fresh: bool = False,
+    cache_mode: str = "auto",
+    model: str = "const",
+    positions: List[str] | None = None,
+) -> Dict:
+    """Floor/mid/ceiling for every active skill player on every team playing
+    in the target week -- not scoped to any roster. Meant for pre-draft prep,
+    when there's no roster to scope to yet (or the league's roster is still
+    empty). Reuses the exact same odds-devig -> quantile -> fantasy-points
+    pipeline as compute_projections(); the only real difference is where the
+    player list comes from (refactored/draft_prep.py, sourced from Sleeper's
+    full player DB) and that it uses a smaller, quota-conscious market set.
+    """
+    print(f"[services] compute_draft_board season={season} week={week} fresh={fresh} positions={positions}")
+    try:
+        roster = sleeper_api.get_user_sleeper_data(username, season)
+    except Exception as e:
+        print(f"[services] draft_board: sleeper scoring lookup failed: {e}")
+        roster = None
+    scoring_rules = (roster or {}).get("scoring_rules", {}) if roster else {}
+
+    eff_mode = 'fresh' if fresh else cache_mode
+    plan = draft_prep.plan_week_for_draft(week=week, regions=region, cache_mode=eff_mode)
+    odds_by_week = _fetch_odds({week: plan}, cache_mode=eff_mode, regions=region)
+    ev_odds = odds_by_week.get(week, {})
+
+    per_player_odds, per_player_summaries = aggregate_by_week(ev_odds, plan)
+
+    info_by_alias: Dict[str, dict] = {}
+    for g in plan.values():
+        for p in g.players:
+            info_by_alias[p["alias"]] = p
+
+    from .range_model import compute_fantasy_range_model
+
+    pos_filter = {p.upper() for p in positions} if positions else None
+    board: List[dict] = []
+    for alias, by_book in per_player_odds.items():
+        pinfo = info_by_alias.get(alias, {})
+        pos = pinfo.get("primary_position")
+        if pos_filter and pos not in pos_filter:
+            continue
+        if (model or "baseline").lower() == "baseline":
+            floor, mid, ceil, _ = compute_fantasy_range(by_book, per_player_summaries.get(alias, {}), scoring_rules)
+        else:
+            floor, mid, ceil, _ = compute_fantasy_range_model(by_book, per_player_summaries.get(alias, {}), scoring_rules, model=model)
+        board.append({
+            "name": pinfo.get("full_name", alias),
+            "pos": pos,
+            "team": pinfo.get("editorial_team_full_name"),
+            "floor": round(floor, 2),
+            "mid": round(mid, 2),
+            "ceiling": round(ceil, 2),
+            "books_used": len(by_book.keys()),
+            "markets_used": len(per_player_summaries.get(alias, {})),
+        })
+
+    board.sort(key=lambda r: r["mid"], reverse=True)
+    payload = {
+        "week": week,
+        "players": board,
+        "ratelimit": ratelimit.format_status(),
+        "ratelimit_info": ratelimit.get_details(),
+    }
+    print(f"[services] compute_draft_board done players={len(board)}")
     return payload
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,6 +139,22 @@ class ApiTestCase(unittest.TestCase):
         self.assertTrue(status.startswith('200'))
         self.assertIsInstance(payload.get('defenses'), list)
 
+    @patch('refactored.api.compute_draft_board')
+    def test_draft_board(self, mock_board):
+        mock_board.return_value = {
+            'week': 'this',
+            'players': [
+                {'name': 'Josh Allen', 'pos': 'QB', 'team': 'Buffalo Bills', 'floor': 15.0, 'mid': 20.0, 'ceiling': 26.0},
+            ],
+            'ratelimit': 'remaining=95%',
+        }
+        status, headers, payload = wsgi_get('/draft-board?username=u&season=2025&week=this&positions=QB,RB')
+        self.assertTrue(status.startswith('200'))
+        self.assertIsInstance(payload.get('players'), list)
+        self.assertEqual(payload['players'][0]['name'], 'Josh Allen')
+        # positions query param should be parsed into a list and passed through
+        self.assertEqual(mock_board.call_args.kwargs.get('positions'), ['QB', 'RB'])
+
     def test_not_found(self):
         status, headers, payload = wsgi_get('/nope')
         self.assertTrue(status.startswith('404'))

--- a/tests/test_draft_prep.py
+++ b/tests/test_draft_prep.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from refactored import draft_prep
+
+FAKE_SLEEPER_PLAYERS = {
+    "1": {"full_name": "Josh Allen", "position": "QB", "team": "BUF"},
+    "2": {"full_name": "James Cook", "position": "RB", "team": "BUF"},
+    "3": {"full_name": "Some Kicker", "position": "K", "team": "BUF"},  # excluded: not a draft position
+    "4": {"full_name": "Free Agent Guy", "position": "WR", "team": None},  # excluded: no team
+    "5": {"full_name": "Retired Guy", "position": "RB", "team": "ZZZ"},  # excluded: unmapped team abbr
+    "6": {"full_name": "Patrick Mahomes", "position": "QB", "team": "KC"},
+}
+
+
+class ActivePlayersByTeamTest(unittest.TestCase):
+    @patch("refactored.draft_prep.sleeper_api.get_players")
+    def test_filters_to_skill_positions_with_a_mapped_team(self, mock_get_players):
+        mock_get_players.return_value = FAKE_SLEEPER_PLAYERS
+        by_team = draft_prep._all_active_players_by_team()
+
+        self.assertIn("Buffalo Bills", by_team)
+        self.assertIn("Kansas City Chiefs", by_team)
+        names = {p["full_name"] for p in by_team["Buffalo Bills"]}
+        self.assertEqual(names, {"Josh Allen", "James Cook"})
+        # No team with only excluded players should show up at all
+        self.assertNotIn(None, by_team)
+
+
+class PlanWeekForDraftTest(unittest.TestCase):
+    @patch("refactored.draft_prep.odds_client.get_nfl_events")
+    @patch("refactored.draft_prep.sleeper_api.get_players")
+    def test_builds_plan_only_for_in_window_games_with_players(self, mock_get_players, mock_get_events):
+        mock_get_players.return_value = FAKE_SLEEPER_PLAYERS
+        from refactored.weekly_windows import compute_week_windows
+        (this_start, this_end), _ = compute_week_windows()
+        in_window_ts = (this_start.replace(hour=13)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        out_of_window_ts = (this_end.replace(year=this_end.year + 1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        mock_get_events.return_value = [
+            {
+                "id": "game-in-window",
+                "home_team": "Buffalo Bills",
+                "away_team": "Kansas City Chiefs",
+                "commence_time": in_window_ts,
+            },
+            {
+                "id": "game-out-of-window",
+                "home_team": "Buffalo Bills",
+                "away_team": "Kansas City Chiefs",
+                "commence_time": out_of_window_ts,
+            },
+            {
+                "id": "game-no-relevant-players",
+                "home_team": "Some Other Team",
+                "away_team": "Another Team",
+                "commence_time": in_window_ts,
+            },
+        ]
+
+        plan = draft_prep.plan_week_for_draft(week="this")
+
+        self.assertIn("game-in-window", plan)
+        self.assertNotIn("game-out-of-window", plan)
+        self.assertNotIn("game-no-relevant-players", plan)
+        game = plan["game-in-window"]
+        self.assertEqual(set(game.markets), set(draft_prep.CORE_DRAFT_MARKETS))
+        player_names = {p["full_name"] for p in game.players}
+        self.assertEqual(player_names, {"Josh Allen", "James Cook", "Patrick Mahomes"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/index.html
+++ b/ui/index.html
@@ -79,6 +79,19 @@
     </section>
 
     <section>
+      <h2>Draft Board (Pre-Season / All Players)</h2>
+      <p class="status">Not scoped to your roster -- every active QB/RB/WR/TE
+      on a team playing the selected week. Uses a smaller set of markets than
+      the weekly views to limit Odds API usage; only fetch this when you
+      actually need it (see CONTRIBUTING.md).</p>
+      <div class="btn-row">
+        <button data-week="this" class="btn-draft-board">Load Draft Board (This Week)</button>
+        <button data-week="next" class="btn-draft-board">Load Draft Board (Next Week)</button>
+      </div>
+      <div id="draft-board" class="results"></div>
+    </section>
+
+    <section>
       <h2>Players - This Week</h2>
       <div class="btn-row">
         <button data-week="this" class="btn-players">Show Players</button>

--- a/ui/script.js
+++ b/ui/script.js
@@ -10,6 +10,7 @@ const appCache = {
   lineups: { this: {}, next: {} },
   defenses: { this: null, next: null },
   projections: { this: null, next: null },
+  draftBoard: { this: null, next: null },
   lastRateLimit: null,
 };
 // Store raw players for local lineup building
@@ -375,6 +376,29 @@ async function showPlayers(week) {
   updateRateLimitDisplays(appCache.lastRateLimit || {});
 }
 
+async function showDraftBoard(week) {
+  // Intentionally not scoped to any roster -- see /draft-board in the API
+  // and CONTRIBUTING.md's "Odds API quota awareness" section. Only fetched
+  // on click, and cached per-week client-side so re-toggling doesn't
+  // re-hit the API.
+  const cached = appCache.draftBoard?.[week];
+  const containerId = 'draft-board';
+  if (!cached) {
+    dbg('showDraftBoard:no-cache', { week });
+    showContainerLoading(containerId, 'Loading draft board (this can take a bit -- it covers every team playing this week)...');
+    const mode = getDataMode();
+    const url = apiUrl('/draft-board', { username: val('username') || 'wesnicol', season: val('season') || '2025', week, mode, model: getModel() });
+    const { ok, data } = await fetchJSON(url);
+    if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load draft board.</div>'; return; }
+    appCache.draftBoard[week] = data;
+    renderPlayers(containerId, data.players || []);
+    updateRateLimitDisplays(data);
+    return;
+  }
+  renderPlayers(containerId, cached.players || []);
+  updateRateLimitDisplays(appCache.lastRateLimit || {});
+}
+
 async function loadDefenses(week) {
   const cached = appCache.defenses?.[week];
   const containerId = week === 'this' ? 'defenses-this' : 'defenses-next';
@@ -490,6 +514,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   document.querySelectorAll('.btn-players').forEach(btn => {
     btn.addEventListener('click', () => showPlayers(btn.dataset.week));
+  });
+  document.querySelectorAll('.btn-draft-board').forEach(btn => {
+    btn.addEventListener('click', () => showDraftBoard(btn.dataset.week));
   });
   if (btnProjThis) btnProjThis.addEventListener('click', () => dbgProjections('this'));
   if (btnProjNext) btnProjNext.addEventListener('click', () => dbgProjections('next'));


### PR DESCRIPTION
## Summary
- New `refactored/draft_prep.py`: sources players from Sleeper's full player DB (not a roster), filtered to QB/RB/WR/TE on a team playing the target week.
- New `compute_draft_board()` in `services.py` + `GET /draft-board` endpoint, reusing the existing de-vig -> quantile -> fantasy-points pipeline.
- Deliberately conservative: no `_alternate` markets by default (bigger quota cost across every team playing that week, not just your roster), opt-in via an explicit UI button, not auto-fetched.
- New UI section reuses the existing generic `renderPlayers()` table -- no new rendering logic.
- 3 new tests (player-DB filtering, week-window planning, API wiring). 22/22 passing overall.

## Test plan
- [x] `python -m pytest tests/`
- [x] `python -m py_compile` across all modules
- [ ] Live smoke test against real Sleeper league + Odds API once merged and run
