### PR TITLE
Anchor draft-board weeks to the schedule, not today's date

### DIFF
--- a/refactored/draft_prep.py
+++ b/refactored/draft_prep.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict, List
+import datetime as _dt
+from typing import Dict, List, Optional, Tuple
 
 import sleeper_api
 from config import SLEEPER_TO_ODDSAPI_TEAM, SLEEPER_ODDS_API_PLAYER_NAME_MAPPING
 from .planner import PlannedGame
-from .weekly_windows import compute_week_windows, in_window
+from .weekly_windows import _prev_weekday, in_window
 from . import odds_client
 
 # Draft prep only covers positions the rest of the app already knows how to
@@ -67,15 +68,61 @@ def _all_active_players_by_team() -> Dict[str, List[dict]]:
     return by_team
 
 
+def _resolve_draft_week_window(
+    events: List[dict],
+    which: str = "this",
+    now_utc: Optional[_dt.datetime] = None,
+) -> Optional[Tuple[_dt.datetime, _dt.datetime]]:
+    """Resolve "Week 1" / "Week 2" for draft purposes.
+
+    Unlike the in-season lineup flow (weekly_windows.compute_week_windows,
+    anchored to "today"), a draft happens once, before the season starts --
+    "today" isn't a meaningful anchor. What matters is the earliest week with
+    any scheduled/priced games at all ("Week 1"), and the week after that
+    ("Week 2"), no matter how far today is from kickoff. Anchoring to "today"
+    instead (the original implementation) meant this silently returned
+    nothing whenever today's nearest Thu-Mon cycle didn't happen to contain
+    real games yet -- which is most of the pre-season.
+
+    Returns None if there are no upcoming games in `events` at all (e.g. the
+    new season's schedule/odds aren't posted yet) -- there's no "Week 1" to
+    anchor to in that case.
+    """
+    now_utc = now_utc or _dt.datetime.utcnow()
+    future_starts: List[_dt.datetime] = []
+    for e in events:
+        ts = e.get("commence_time")
+        if not ts:
+            continue
+        try:
+            dt = _dt.datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            continue
+        if dt > now_utc:
+            future_starts.append(dt)
+    if not future_starts:
+        return None
+
+    week1_start = _prev_weekday(min(future_starts), 3)  # Thursday anchoring the earliest game
+    week_start = week1_start if which == "this" else week1_start + _dt.timedelta(days=7)
+    week_end = week_start + _dt.timedelta(days=4, hours=23, minutes=59, seconds=59)
+    return week_start, week_end
+
+
 def plan_week_for_draft(week: str = "this", regions: str = "us", cache_mode: str = "auto") -> Dict[str, PlannedGame]:
     """Like planner.plan_relevant_games_and_markets, but for every active
     skill player on every team playing in the target week -- not just one
     roster. Returns game_id -> PlannedGame for the requested window only.
-    """
-    (this_start, this_end), (next_start, next_end) = compute_week_windows()
-    start, end = (this_start, this_end) if week == "this" else (next_start, next_end)
 
+    `week="this"` means "Week 1" (the earliest week with scheduled games)
+    and `week="next"` means "Week 2" -- see _resolve_draft_week_window.
+    """
     events = odds_client.get_nfl_events(regions=regions, mode=cache_mode)
+    window = _resolve_draft_week_window(events, which=week)
+    if window is None:
+        return {}
+    start, end = window
+
     by_team = _all_active_players_by_team()
 
     plan: Dict[str, PlannedGame] = {}

--- a/refactored/services.py
+++ b/refactored/services.py
@@ -528,13 +528,32 @@ def compute_draft_board(
         })
 
     board.sort(key=lambda r: r["mid"], reverse=True)
+
+    # Surface the actual resolved date range so "Week 1"/"Week 2" is never
+    # ambiguous -- these are schedule-anchored (earliest games found), not
+    # anchored to today, so they won't line up with the calendar in any
+    # obvious way. See draft_prep._resolve_draft_week_window.
+    window_start = window_end = None
+    if plan:
+        game_starts = sorted(g.commence_time for g in plan.values())
+        window_start, window_end = game_starts[0], game_starts[-1]
+
     payload = {
         "week": week,
+        "window_start": window_start,
+        "window_end": window_end,
         "players": board,
         "ratelimit": ratelimit.format_status(),
         "ratelimit_info": ratelimit.get_details(),
     }
-    print(f"[services] compute_draft_board done players={len(board)}")
+    if not plan:
+        payload["message"] = (
+            "No scheduled games found yet for this window. Draft-board weeks "
+            "are anchored to the earliest games in the odds feed, not "
+            "today's date -- check back once the season's schedule/odds are "
+            "posted (usually a couple weeks before Week 1)."
+        )
+    print(f"[services] compute_draft_board done players={len(board)} window=({window_start}..{window_end})")
     return payload
 
 

--- a/tests/test_draft_prep.py
+++ b/tests/test_draft_prep.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 import sys
 import unittest
@@ -33,45 +34,94 @@ class ActivePlayersByTeamTest(unittest.TestCase):
         self.assertNotIn(None, by_team)
 
 
+def _ts(d: dt.datetime) -> str:
+    return d.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class ResolveDraftWeekWindowTest(unittest.TestCase):
+    """Draft weeks are anchored to the earliest scheduled game, not to
+    "today" -- a draft happens once, before the season starts, so "today"
+    isn't a meaningful reference point the way it is for the in-season
+    lineup views (weekly_windows.compute_week_windows)."""
+
+    def test_none_when_no_upcoming_games(self):
+        now = dt.datetime(2026, 8, 19)
+        past_game = {"commence_time": _ts(now - dt.timedelta(days=5))}
+        self.assertIsNone(draft_prep._resolve_draft_week_window([past_game], which="this", now_utc=now))
+
+    def test_week1_anchors_to_earliest_future_game_not_today(self):
+        # "Today" is deep in the off-season; the earliest real game is over
+        # a month out. Week 1 should anchor to that game, not to today.
+        now = dt.datetime(2026, 8, 19)
+        earliest_game = dt.datetime(2026, 9, 10, 20, 0, 0)  # ~3 weeks out
+        events = [{"commence_time": _ts(earliest_game)}]
+
+        window = draft_prep._resolve_draft_week_window(events, which="this", now_utc=now)
+        self.assertIsNotNone(window)
+        start, end = window
+        self.assertLessEqual(start, earliest_game)
+        self.assertLessEqual(earliest_game, end)
+        # Window should NOT be anchored anywhere near "today"
+        self.assertGreater(start, now + dt.timedelta(days=14))
+
+    def test_week2_is_exactly_one_week_after_week1(self):
+        now = dt.datetime(2026, 8, 19)
+        earliest_game = dt.datetime(2026, 9, 10, 20, 0, 0)
+        events = [{"commence_time": _ts(earliest_game)}]
+
+        week1_start, _ = draft_prep._resolve_draft_week_window(events, which="this", now_utc=now)
+        week2_start, _ = draft_prep._resolve_draft_week_window(events, which="next", now_utc=now)
+        self.assertEqual(week2_start - week1_start, dt.timedelta(days=7))
+
+
 class PlanWeekForDraftTest(unittest.TestCase):
     @patch("refactored.draft_prep.odds_client.get_nfl_events")
     @patch("refactored.draft_prep.sleeper_api.get_players")
-    def test_builds_plan_only_for_in_window_games_with_players(self, mock_get_players, mock_get_events):
+    def test_builds_plan_for_week1_and_week2_separately(self, mock_get_players, mock_get_events):
         mock_get_players.return_value = FAKE_SLEEPER_PLAYERS
-        from refactored.weekly_windows import compute_week_windows
-        (this_start, this_end), _ = compute_week_windows()
-        in_window_ts = (this_start.replace(hour=13)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        out_of_window_ts = (this_end.replace(year=this_end.year + 1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        now = dt.datetime.utcnow()
+        week1_ts = _ts(now + dt.timedelta(days=10))
+        week2_ts = _ts(now + dt.timedelta(days=17))
         mock_get_events.return_value = [
             {
-                "id": "game-in-window",
+                "id": "game-week1",
                 "home_team": "Buffalo Bills",
                 "away_team": "Kansas City Chiefs",
-                "commence_time": in_window_ts,
+                "commence_time": week1_ts,
             },
             {
-                "id": "game-out-of-window",
+                "id": "game-week2",
                 "home_team": "Buffalo Bills",
                 "away_team": "Kansas City Chiefs",
-                "commence_time": out_of_window_ts,
+                "commence_time": week2_ts,
             },
             {
                 "id": "game-no-relevant-players",
                 "home_team": "Some Other Team",
                 "away_team": "Another Team",
-                "commence_time": in_window_ts,
+                "commence_time": week1_ts,
             },
         ]
 
-        plan = draft_prep.plan_week_for_draft(week="this")
+        week1_plan = draft_prep.plan_week_for_draft(week="this")
+        week2_plan = draft_prep.plan_week_for_draft(week="next")
 
-        self.assertIn("game-in-window", plan)
-        self.assertNotIn("game-out-of-window", plan)
-        self.assertNotIn("game-no-relevant-players", plan)
-        game = plan["game-in-window"]
+        self.assertIn("game-week1", week1_plan)
+        self.assertNotIn("game-week2", week1_plan)
+        self.assertNotIn("game-no-relevant-players", week1_plan)
+
+        self.assertIn("game-week2", week2_plan)
+        self.assertNotIn("game-week1", week2_plan)
+
+        game = week1_plan["game-week1"]
         self.assertEqual(set(game.markets), set(draft_prep.CORE_DRAFT_MARKETS))
         player_names = {p["full_name"] for p in game.players}
         self.assertEqual(player_names, {"Josh Allen", "James Cook", "Patrick Mahomes"})
+
+    @patch("refactored.draft_prep.odds_client.get_nfl_events")
+    def test_empty_plan_when_no_games_scheduled_yet(self, mock_get_events):
+        mock_get_events.return_value = []
+        self.assertEqual(draft_prep.plan_week_for_draft(week="this"), {})
 
 
 if __name__ == "__main__":

--- a/ui/index.html
+++ b/ui/index.html
@@ -81,12 +81,18 @@
     <section>
       <h2>Draft Board (Pre-Season / All Players)</h2>
       <p class="status">Not scoped to your roster -- every active QB/RB/WR/TE
-      on a team playing the selected week. Uses a smaller set of markets than
-      the weekly views to limit Odds API usage; only fetch this when you
-      actually need it (see CONTRIBUTING.md).</p>
+      on a team playing the selected week. "Week 1" / "Week 2" are anchored to
+      the earliest games found in the odds feed, not today's date (a draft
+      happens once, before the season, so "today" isn't a useful anchor the
+      way it is for the weekly lineup views below) -- the loaded date range
+      is shown once you load a week. This is a single week's market-implied
+      outlook, not a full-season projection: a real, useful signal for
+      role/opportunity, but not a replacement for season-long ADP/rankings.
+      Uses a smaller set of markets than the weekly views to limit Odds API
+      usage; only fetch this when you actually need it (see CONTRIBUTING.md).</p>
       <div class="btn-row">
-        <button data-week="this" class="btn-draft-board">Load Draft Board (This Week)</button>
-        <button data-week="next" class="btn-draft-board">Load Draft Board (Next Week)</button>
+        <button data-week="this" class="btn-draft-board">Load Week 1</button>
+        <button data-week="next" class="btn-draft-board">Load Week 2</button>
       </div>
       <div id="draft-board" class="results"></div>
     </section>

--- a/ui/script.js
+++ b/ui/script.js
@@ -376,6 +376,28 @@ async function showPlayers(week) {
   updateRateLimitDisplays(appCache.lastRateLimit || {});
 }
 
+function _renderDraftBoard(containerId, data) {
+  // "Week 1"/"Week 2" are schedule-anchored (earliest games in the odds
+  // feed), not tied to today's date -- always show the resolved date range
+  // (or the "nothing scheduled yet" message) so it's never ambiguous what's
+  // actually loaded. renderPlayers() owns the table itself; this just adds
+  // a header in front of it.
+  renderPlayers(containerId, data.players || []);
+  const c = $(containerId);
+  if (!c) return;
+  let header = '';
+  if (data.message) {
+    header = `<div class="status draft-board-note">${data.message}</div>`;
+  } else if (data.window_start && data.window_end) {
+    const fmt = (iso) => {
+      try { return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }); }
+      catch (e) { return iso; }
+    };
+    header = `<div class="status draft-board-note">Games: ${fmt(data.window_start)} – ${fmt(data.window_end)}</div>`;
+  }
+  if (header) c.insertAdjacentHTML('afterbegin', header);
+}
+
 async function showDraftBoard(week) {
   // Intentionally not scoped to any roster -- see /draft-board in the API
   // and CONTRIBUTING.md's "Odds API quota awareness" section. Only fetched
@@ -391,11 +413,11 @@ async function showDraftBoard(week) {
     const { ok, data } = await fetchJSON(url);
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load draft board.</div>'; return; }
     appCache.draftBoard[week] = data;
-    renderPlayers(containerId, data.players || []);
+    _renderDraftBoard(containerId, data);
     updateRateLimitDisplays(data);
     return;
   }
-  renderPlayers(containerId, cached.players || []);
+  _renderDraftBoard(containerId, cached);
   updateRateLimitDisplays(appCache.lastRateLimit || {});
 }
 


### PR DESCRIPTION
## Summary
- `refactored/draft_prep._resolve_draft_week_window()`: "Week 1" now anchors to the earliest scheduled game found in the odds feed, "Week 2" to the week after -- not to today's date. Fixes the draft board silently returning empty during most of the pre-season.
- `compute_draft_board()` now returns `window_start`/`window_end` (the actual resolved date range) and a clear `message` when nothing is scheduled yet, instead of a bare empty list.
- UI: button labels are now "Load Week 1"/"Load Week 2", with the resolved date range (or the "nothing scheduled yet" message) shown above the results table.
- Copy updated to be explicit this is a single week's market-implied outlook, not a season-long projection.
- 4 new/rewritten tests (window resolution incl. the "no games yet" case, week1 vs week2 separation). 26/26 passing overall.

## Test plan
- [x] `python -m pytest tests/`
- [x] `python -m py_compile` across all modules
- [x] Manually verified resolved windows against a realistic pre-season date
