### PR TITLE
Identify "you" by league ID + team, not username

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,32 @@ Override the command or environment variables in the compose file if you need to
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the branching model
 (`feature/*` / `dev/*` / `main`) and repo-hygiene rules.
 
+## League / team identity
+The UI identifies "you" by Sleeper **league ID + team**, not username: on
+first load it prompts for your league ID (stored as a cookie), then a
+dropdown to pick which roster is yours (also cookie'd). This is deliberately
+more precise than username-based lookup, which just grabs "the first league
+this username is in" and silently picks the wrong league for anyone in more
+than one. The league's own Sleeper `status` (`pre_draft`/`drafting` vs.
+`in_season`/`complete`) decides whether the UI defaults to the draft board or
+the weekly lineup view. `GET /league/resolve?league_id=` (status + team list)
+is what powers this; every other endpoint accepts `league_id`+`roster_id` as
+an alternative to `username`+`season`, with `league_id` taking priority when
+both are present (see `services._resolve_identity`). The username/season
+fields still work as a fallback for anyone who hasn't set up a league.
+
 ## Project Structure
 - `refactored/`: **This is the real application.** `refactored/api.py` is the
   entrypoint (`CMD` in the `Dockerfile`) — a stdlib WSGI server exposing
-  `/health`, `/projections`, `/lineup`, `/lineup/diffs`, `/defenses`,
-  `/draft-board`, `/player/odds`, `/defense/odds`, and `/dashboard`, and
-  serving the UI under `/` and `/ui/*`. See `refactored/services.py` for the
-  orchestration layer, `refactored/range_model.py` + `refactored/prob_models.py`
-  for how betting-line probabilities become floor/mid/ceiling fantasy point
-  ranges, `refactored/aggregator.py` + `refactored/planner.py` for how odds
-  are fetched/grouped for your roster, `refactored/draft_prep.py` for the
-  same thing but for every player league-wide (pre-draft, before you have a
+  `/health`, `/league/resolve`, `/projections`, `/lineup`, `/lineup/diffs`,
+  `/defenses`, `/draft-board`, `/player/odds`, `/defense/odds`, and
+  `/dashboard`, and serving the UI under `/` and `/ui/*`. See
+  `refactored/services.py` for the orchestration layer,
+  `refactored/range_model.py` + `refactored/prob_models.py` for how
+  betting-line probabilities become floor/mid/ceiling fantasy point ranges,
+  `refactored/aggregator.py` + `refactored/planner.py` for how odds are
+  fetched/grouped for your roster, `refactored/draft_prep.py` for the same
+  thing but for every player league-wide (pre-draft, before you have a
   roster to scope to), and `refactored/odds_client.py` +
   `refactored/ratelimit.py` for caching and Odds-API rate-limit tracking.
 - `config.py`: Loads environment configuration and defines shared constants

--- a/refactored/api.py
+++ b/refactored/api.py
@@ -19,7 +19,7 @@ from typing import Callable
 
 from . import ratelimit
 from . import services  # for detail endpoints
-from .services import compute_projections, compute_book_coverage, build_lineup, build_lineup_diffs, list_defenses, build_dashboard, compute_draft_board
+from .services import compute_projections, compute_book_coverage, build_lineup, build_lineup_diffs, list_defenses, build_dashboard, compute_draft_board, resolve_league
 
 # Module-level debug flag (defaults to False). Can be enabled via --debug CLI.
 _DEBUG_FLAG = False
@@ -111,6 +111,19 @@ def application(environ, start_response):
         v = qs.get(name)
         return v[0] if v else default
 
+    def q_identity():
+        """league_id/roster_id, when present, take priority over
+        username/season -- see services._resolve_identity."""
+        league_id = q("league_id", "") or None
+        roster_id_raw = q("roster_id", "")
+        roster_id = None
+        if roster_id_raw:
+            try:
+                roster_id = int(roster_id_raw)
+            except ValueError:
+                roster_id = None
+        return league_id, roster_id
+
     _dprint(f"[api] {method} {path} qs={qs}")
 
     try:
@@ -125,6 +138,17 @@ def application(environ, start_response):
             _dprint("[api] GET /health")
             return _json_response(start_response, "200 OK", {"status": "ok", "ratelimit": ratelimit.format_status(), "ratelimit_info": ratelimit.get_details()})
 
+        if path == "/league/resolve":
+            league_id = q("league_id", "")
+            t0 = time.time()
+            _dprint(f"[api] league/resolve league_id={league_id}")
+            if not league_id:
+                return _json_response(start_response, "400 Bad Request", {"error": "league_id_required"})
+            data = resolve_league(league_id)
+            status = "404 Not Found" if data.get("error") else "200 OK"
+            _dprint(f"[api] league/resolve done status={data.get('status')} teams={len(data.get('teams', []))} dt={(time.time()-t0):.2f}s")
+            return _json_response(start_response, status, data)
+
         if path == "/projections":
             username = q("username", "wesnicol")
             season = q("season", "2025")
@@ -133,9 +157,10 @@ def application(environ, start_response):
             model = q("model", "const")
             fresh = q("fresh", "0") in ("1", "true", "True")
             mode = q("mode", "auto")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] projections user={username} season={season} week={week} region={region} mode={mode} model={model} fresh={fresh}")
-            data = compute_projections(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model)
+            _dprint(f"[api] projections user={username} season={season} week={week} region={region} mode={mode} model={model} fresh={fresh} league_id={league_id} roster_id={roster_id}")
+            data = compute_projections(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, league_id=league_id, roster_id=roster_id)
             _dprint(f"[api] projections done players={len(data.get('players', []))} dt={(time.time()-t0):.2f}s")
             return _json_response(start_response, "200 OK", data)
 
@@ -147,9 +172,10 @@ def application(environ, start_response):
             model = q("model", "const")
             fresh = q("fresh", "0") in ("1", "true", "True")
             mode = q("mode", "auto")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] book-coverage user={username} season={season} week={week} region={region} mode={mode} model={model} fresh={fresh}")
-            data = compute_book_coverage(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model)
+            _dprint(f"[api] book-coverage user={username} season={season} week={week} region={region} mode={mode} model={model} fresh={fresh} league_id={league_id} roster_id={roster_id}")
+            data = compute_book_coverage(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, league_id=league_id, roster_id=roster_id)
             rows = len((data.get('coverage') or {}).get('rows', []))
             _dprint(f"[api] book-coverage done rows={rows} dt={(time.time()-t0):.2f}s")
             return _json_response(start_response, "200 OK", data)
@@ -163,10 +189,11 @@ def application(environ, start_response):
             model = q("model", "const")
             fresh = q("fresh", "0") in ("1", "true", "True")
             mode = q("mode", "auto")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] lineup user={username} season={season} week={week} target={target} region={region} mode={mode} model={model} fresh={fresh}")
-            proj = compute_projections(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model)
-            def_data = list_defenses(username=username, season=season, week=week, scope="owned", region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode))
+            _dprint(f"[api] lineup user={username} season={season} week={week} target={target} region={region} mode={mode} model={model} fresh={fresh} league_id={league_id} roster_id={roster_id}")
+            proj = compute_projections(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, league_id=league_id, roster_id=roster_id)
+            def_data = list_defenses(username=username, season=season, week=week, scope="owned", region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), league_id=league_id, roster_id=roster_id)
             lineup = build_lineup(proj.get("players", []), target=target, defenses=def_data.get("defenses", []))
             lineup["ratelimit"] = ratelimit.format_status()
             lineup["ratelimit_info"] = ratelimit.get_details()
@@ -181,10 +208,11 @@ def application(environ, start_response):
             model = q("model", "const")
             fresh = q("fresh", "0") in ("1", "true", "True")
             mode = q("mode", "auto")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] lineup/diffs user={username} season={season} week={week} region={region} mode={mode} model={model} fresh={fresh}")
-            proj = compute_projections(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model)
-            def_data = list_defenses(username=username, season=season, week=week, scope="owned", region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode))
+            _dprint(f"[api] lineup/diffs user={username} season={season} week={week} region={region} mode={mode} model={model} fresh={fresh} league_id={league_id} roster_id={roster_id}")
+            proj = compute_projections(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, league_id=league_id, roster_id=roster_id)
+            def_data = list_defenses(username=username, season=season, week=week, scope="owned", region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), league_id=league_id, roster_id=roster_id)
             diffs = build_lineup_diffs(proj.get("players", []), defenses=def_data.get("defenses", []))
             diffs["ratelimit"] = ratelimit.format_status()
             diffs["ratelimit_info"] = ratelimit.get_details()
@@ -199,9 +227,10 @@ def application(environ, start_response):
             region = q("region", "us")
             fresh = q("fresh", "0") in ("1", "true", "True")
             mode = q("mode", "auto")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] defenses user={username} season={season} week={week} scope={scope} region={region} mode={mode} fresh={fresh}")
-            data = list_defenses(username=username, season=season, week=week, scope=scope, fresh=fresh, cache_mode=('fresh' if fresh else mode), region=region)
+            _dprint(f"[api] defenses user={username} season={season} week={week} scope={scope} region={region} mode={mode} fresh={fresh} league_id={league_id} roster_id={roster_id}")
+            data = list_defenses(username=username, season=season, week=week, scope=scope, fresh=fresh, cache_mode=('fresh' if fresh else mode), region=region, league_id=league_id, roster_id=roster_id)
             _dprint(f"[api] defenses done rows={len(data.get('defenses', []))} dt={(time.time()-t0):.2f}s")
             return _json_response(start_response, "200 OK", data)
 
@@ -213,9 +242,10 @@ def application(environ, start_response):
             name = q("name", "")
             model = q("model", "const")
             mode = q("mode", "auto")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] player/odds user={username} season={season} week={week} name={name} model={model} mode={mode}")
-            data = services.get_player_odds_details(username=username, season=season, week=week, region=region, name=name, cache_mode=mode, model=model)
+            _dprint(f"[api] player/odds user={username} season={season} week={week} name={name} model={model} mode={mode} league_id={league_id} roster_id={roster_id}")
+            data = services.get_player_odds_details(username=username, season=season, week=week, region=region, name=name, cache_mode=mode, model=model, league_id=league_id, roster_id=roster_id)
             _dprint(f"[api] player/odds done markets={len(data.get('markets', {}))} dt={(time.time()-t0):.2f}s")
             return _json_response(start_response, "200 OK", data)
 
@@ -242,9 +272,10 @@ def application(environ, start_response):
             mode = q("mode", "auto")
             positions_raw = q("positions", "")
             positions = [p.strip().upper() for p in positions_raw.split(",") if p.strip()] or None
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] draft-board season={season} week={week} region={region} mode={mode} model={model} fresh={fresh} positions={positions}")
-            data = compute_draft_board(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, positions=positions)
+            _dprint(f"[api] draft-board season={season} week={week} region={region} mode={mode} model={model} fresh={fresh} positions={positions} league_id={league_id} roster_id={roster_id}")
+            data = compute_draft_board(username=username, season=season, week=week, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), model=model, positions=positions, league_id=league_id, roster_id=roster_id)
             _dprint(f"[api] draft-board done players={len(data.get('players', []))} dt={(time.time()-t0):.2f}s")
             return _json_response(start_response, "200 OK", data)
 
@@ -258,9 +289,10 @@ def application(environ, start_response):
             weeks = q("weeks", "this")  # default lighter workload
             def_scope = q("def_scope", "owned")
             include_players = q("include_players", "1") in ("1", "true", "True")
+            league_id, roster_id = q_identity()
             t0 = time.time()
-            _dprint(f"[api] dashboard user={username} season={season} region={region} mode={mode} model={model} fresh={fresh} weeks={weeks} def_scope={def_scope} include_players={include_players}")
-            data = build_dashboard(username=username, season=season, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), weeks=weeks, def_scope=def_scope, include_players=include_players, model=model)
+            _dprint(f"[api] dashboard user={username} season={season} region={region} mode={mode} model={model} fresh={fresh} weeks={weeks} def_scope={def_scope} include_players={include_players} league_id={league_id} roster_id={roster_id}")
+            data = build_dashboard(username=username, season=season, region=region, fresh=fresh, cache_mode=('fresh' if fresh else mode), weeks=weeks, def_scope=def_scope, include_players=include_players, model=model, league_id=league_id, roster_id=roster_id)
             _dprint(f"[api] dashboard done rl={data.get('ratelimit')} dt={(time.time()-t0):.2f}s")
             return _json_response_adv(environ, start_response, data)
 
@@ -293,7 +325,8 @@ def main():
 Starting Odds Fantasy API
 Endpoints:
   GET /health
-  GET /projections?username=&season=&week=this|next&fresh=0|1
+  GET /league/resolve?league_id=  (status + team list, for the league/team picker)
+  GET /projections?username=&season=&week=this|next&fresh=0|1  (or league_id=&roster_id=)
   GET /lineup?username=&season=&week=this|next&target=mid|floor|ceiling&fresh=0|1
   GET /lineup/diffs?username=&season=&week=this|next&fresh=0|1
   GET /defenses?username=&season=&week=this|next&scope=owned|available|both&fresh=0|1

--- a/refactored/services.py
+++ b/refactored/services.py
@@ -32,6 +32,48 @@ COVERAGE_MARKET_ORDER = [
 ]
 
 
+def _resolve_identity(username: str, season: str, league_id: Optional[str] = None, roster_id: Optional[int] = None) -> dict:
+    """Resolve {'players', 'scoring_rules', ...} for the caller's team.
+
+    `league_id` (when given) is authoritative: an explicit league+team
+    selection beats the legacy username-based "first league for this user"
+    guess, which silently picks the wrong league for anyone in more than
+    one. Falls back to the username/season path when league_id isn't
+    provided, so existing callers keep working unchanged.
+    """
+    if league_id:
+        return sleeper_api.get_league_roster_data(league_id, roster_id=roster_id)
+    return sleeper_api.get_user_sleeper_data(username, season) or {}
+
+
+def resolve_league(league_id: str) -> Dict:
+    """Given a Sleeper league ID, return everything the UI needs to drive
+    the "paste your league ID -> pick your team" flow:
+      - status: Sleeper's own "pre_draft" | "drafting" | "in_season" |
+        "complete" -- the actual source of truth for whether the league has
+        drafted yet, used to decide whether to default to the draft board
+        or the weekly lineup views.
+      - teams: one entry per roster, for a team picker.
+    """
+    try:
+        league = sleeper_api.get_league(league_id)
+    except Exception as e:
+        print(f"[services] resolve_league: lookup failed for {league_id}: {e}")
+        return {"error": "league_not_found", "league_id": league_id}
+    try:
+        teams = sleeper_api.get_league_teams(league_id)
+    except Exception as e:
+        print(f"[services] resolve_league: team list failed for {league_id}: {e}")
+        teams = []
+    return {
+        "league_id": league_id,
+        "name": league.get("name"),
+        "season": league.get("season"),
+        "status": league.get("status"),
+        "teams": teams,
+    }
+
+
 def _pick_week_window(which: str, now_utc: Optional[dt.datetime] = None):
     (this_start, this_end), (next_start, next_end) = compute_week_windows(now_utc)
     return (this_start, this_end) if which == "this" else (next_start, next_end)
@@ -70,12 +112,12 @@ def _fetch_odds(plan_by_week: Dict[str, Dict[str, object]], cache_mode: str, reg
     return out
 
 
-def compute_projections(username: str, season: str, week: str = "this", region: str = "us", fresh: bool = False, cache_mode: str = "auto", model: str = "const") -> Dict:
-    print(f"[services] compute_projections user={username} season={season} week={week} fresh={fresh}")
+def compute_projections(username: str, season: str, week: str = "this", region: str = "us", fresh: bool = False, cache_mode: str = "auto", model: str = "const", league_id: Optional[str] = None, roster_id: Optional[int] = None) -> Dict:
+    print(f"[services] compute_projections user={username} season={season} week={week} fresh={fresh} league_id={league_id} roster_id={roster_id}")
     # In-process TTL cache
     ttl = int(os.getenv("SERVICE_CACHE_TTL", "120"))
     _proj_cache = getattr(compute_projections, "_cache", {})
-    key = (username, season, week, region, model)
+    key = (username, season, week, region, model, league_id, roster_id)
     now = time.time()
     if not fresh and key in _proj_cache:
         ts, payload = _proj_cache[key]
@@ -83,7 +125,7 @@ def compute_projections(username: str, season: str, week: str = "this", region: 
             print(f"[services] compute_projections cache hit key={key} age={int(now-ts)}s")
             return payload
     try:
-        roster = sleeper_api.get_user_sleeper_data(username, season)
+        roster = _resolve_identity(username, season, league_id, roster_id)
     except Exception as e:
         print(f"[services] sleeper error: {e}")
         # Graceful fallback: continue with empty roster so UI can load
@@ -474,6 +516,8 @@ def compute_draft_board(
     cache_mode: str = "auto",
     model: str = "const",
     positions: List[str] | None = None,
+    league_id: Optional[str] = None,
+    roster_id: Optional[int] = None,
 ) -> Dict:
     """Floor/mid/ceiling for every active skill player on every team playing
     in the target week -- not scoped to any roster. Meant for pre-draft prep,
@@ -482,10 +526,14 @@ def compute_draft_board(
     pipeline as compute_projections(); the only real difference is where the
     player list comes from (refactored/draft_prep.py, sourced from Sleeper's
     full player DB) and that it uses a smaller, quota-conscious market set.
+
+    Only `scoring_rules` is needed here (there's no roster to scope the
+    player list to -- that's the whole point), so this works fine with just
+    a league_id and no roster_id, i.e. before a team has been picked.
     """
-    print(f"[services] compute_draft_board season={season} week={week} fresh={fresh} positions={positions}")
+    print(f"[services] compute_draft_board season={season} week={week} fresh={fresh} positions={positions} league_id={league_id}")
     try:
-        roster = sleeper_api.get_user_sleeper_data(username, season)
+        roster = _resolve_identity(username, season, league_id, roster_id)
     except Exception as e:
         print(f"[services] draft_board: sleeper scoring lookup failed: {e}")
         roster = None
@@ -565,6 +613,8 @@ def compute_book_coverage(
     fresh: bool = False,
     cache_mode: str = "auto",
     model: str = "const",
+    league_id: Optional[str] = None,
+    roster_id: Optional[int] = None,
 ) -> Dict:
     data = compute_projections(
         username=username,
@@ -574,6 +624,8 @@ def compute_book_coverage(
         fresh=fresh,
         cache_mode=cache_mode,
         model=model,
+        league_id=league_id,
+        roster_id=roster_id,
     )
     coverage = data.get("book_coverage") or {}
     markets = list(coverage.get("markets") or COVERAGE_MARKET_ORDER)
@@ -770,14 +822,31 @@ def _implied_total(game_total: float, team_spread: float) -> float:
     return game_total / 2.0 - team_spread / 2.0
 
 
-def _def_ownership_map(username: str, season: str) -> Tuple[dict, str | None]:
-    """Return (team_fullname -> {id, name}, current_user_id)."""
+def _def_ownership_map(username: str, season: str, league_id: Optional[str] = None, roster_id: Optional[int] = None) -> Tuple[dict, str | None]:
+    """Return (team_fullname -> {id, name}, current_owner_id).
+
+    current_owner_id identifies "you" for the owned_by_current flag in
+    list_defenses -- resolved from the explicit roster_id when a league_id
+    is given (the authoritative path, since it doesn't depend on guessing
+    which of a user's leagues is the right one), or from the legacy
+    username-based Sleeper user_id lookup otherwise.
+    """
     try:
-        league_id, user_id = sleeper_api.get_league_id_for_user(username, season)
-        if not league_id:
+        user_id = None
+        if league_id:
+            lid = league_id
+        else:
+            lid, user_id = sleeper_api.get_league_id_for_user(username, season)
+        if not lid:
             return {}, None
-        rosters = sleeper_api.get_league_rosters(league_id)
-        users = sleeper_api.get_league_users(league_id)
+        rosters = sleeper_api.get_league_rosters(lid)
+        users = sleeper_api.get_league_users(lid)
+
+        current_owner_id = user_id
+        if league_id and roster_id is not None:
+            match = next((r for r in (rosters or []) if r.get('roster_id') == roster_id), None)
+            current_owner_id = match.get('owner_id') if match else None
+
         # Map owner_id -> display name (fallback to username/id)
         owner_name: dict = {}
         for u in users or []:
@@ -800,18 +869,18 @@ def _def_ownership_map(username: str, season: str) -> Tuple[dict, str | None]:
                         team_to_owner[full] = {"id": oid, "name": disp}
                 except Exception:
                     continue
-        return team_to_owner, user_id
+        return team_to_owner, current_owner_id
     except Exception as e:
         print(f"[services] def ownership mapping error: {e}")
         return {}, None
 
 
-def list_defenses(username: str, season: str, week: str = "this", scope: str = "both", fresh: bool = False, cache_mode: str = "auto", region: str = "us") -> Dict:
-    print(f"[services] list_defenses user={username} season={season} week={week} scope={scope} fresh={fresh}")
+def list_defenses(username: str, season: str, week: str = "this", scope: str = "both", fresh: bool = False, cache_mode: str = "auto", region: str = "us", league_id: Optional[str] = None, roster_id: Optional[int] = None) -> Dict:
+    print(f"[services] list_defenses user={username} season={season} week={week} scope={scope} fresh={fresh} league_id={league_id} roster_id={roster_id}")
     # In-process TTL cache
     ttl = int(os.getenv("SERVICE_CACHE_TTL", "120"))
     _def_cache = getattr(list_defenses, "_cache", {})
-    key = (username, season, week, scope)
+    key = (username, season, week, scope, league_id, roster_id)
     now = time.time()
     if not fresh and key in _def_cache:
         ts, payload = _def_cache[key]
@@ -823,14 +892,14 @@ def list_defenses(username: str, season: str, week: str = "this", scope: str = "
 
     # Scoring rules for converting opponent implied totals into DEF fantasy points
     try:
-        roster_for_scoring = sleeper_api.get_user_sleeper_data(username, season)
+        roster_for_scoring = _resolve_identity(username, season, league_id, roster_id)
         scoring_rules = (roster_for_scoring or {}).get("scoring_rules", {})
     except Exception as e:
         print(f"[services] defenses: scoring rules lookup failed: {e}")
         scoring_rules = {}
 
     # Build ownership map across entire league
-    team_to_owner, current_uid = _def_ownership_map(username, season)
+    team_to_owner, current_uid = _def_ownership_map(username, season, league_id, roster_id)
     # All teams (full names)
     all_teams = list(SLEEPER_TO_ODDSAPI_TEAM.values())
     # Scope handling remains, but default 'both' -> include all
@@ -940,6 +1009,8 @@ def build_dashboard(
     def_scope: str = "owned",  # 'owned' | 'available' | 'both'
     include_players: bool = True,
     model: str = "const",
+    league_id: Optional[str] = None,
+    roster_id: Optional[int] = None,
 ) -> Dict:
     """Build a single payload for UI: lineups and defenses with optional scoping.
 
@@ -960,17 +1031,17 @@ def build_dashboard(
     proj_this = None
     proj_next = None
     if weeks in ("this", "both"):
-        proj_this = compute_projections(username=username, season=season, week="this", region=region, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode), model=model)
+        proj_this = compute_projections(username=username, season=season, week="this", region=region, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode), model=model, league_id=league_id, roster_id=roster_id)
     if weeks in ("next", "both"):
-        proj_next = compute_projections(username=username, season=season, week="next", region=region, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode), model=model)
+        proj_next = compute_projections(username=username, season=season, week="next", region=region, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode), model=model, league_id=league_id, roster_id=roster_id)
 
     # Defenses scoped by weeks and scope parameter
     defs_this = None
     defs_next = None
     if weeks in ("this", "both"):
-        defs_this = list_defenses(username=username, season=season, week="this", scope=def_scope, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode))
+        defs_this = list_defenses(username=username, season=season, week="this", scope=def_scope, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode), league_id=league_id, roster_id=roster_id)
     if weeks in ("next", "both"):
-        defs_next = list_defenses(username=username, season=season, week="next", scope=def_scope, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode))
+        defs_next = list_defenses(username=username, season=season, week="next", scope=def_scope, fresh=fresh, cache_mode=('fresh' if fresh else cache_mode), league_id=league_id, roster_id=roster_id)
 
     def _owned(defs_payload: dict | None) -> List[dict]:
         rows = (defs_payload or {}).get("defenses", []) or []
@@ -1023,7 +1094,7 @@ def _norm_name(s: str) -> str:
         return s or ""
 
 
-def get_player_odds_details(username: str, season: str, week: str = "this", region: str = "us", name: str = "", cache_mode: str = "auto", model: str = "const") -> Dict:
+def get_player_odds_details(username: str, season: str, week: str = "this", region: str = "us", name: str = "", cache_mode: str = "auto", model: str = "const", league_id: Optional[str] = None, roster_id: Optional[int] = None) -> Dict:
     """Return per-book odds and market summaries used for a single player.
 
     Emphasizes markets by estimated impact on fantasy points (mean stat * scoring multiplier).
@@ -1031,7 +1102,7 @@ def get_player_odds_details(username: str, season: str, week: str = "this", regi
     (this_start, this_end), (next_start, next_end) = compute_week_windows()
     eff_mode = cache_mode
     # Roster & planning (to get scoring rules and player mapping)
-    roster = sleeper_api.get_user_sleeper_data(username, season)
+    roster = _resolve_identity(username, season, league_id, roster_id)
     scoring_rules = roster.get("scoring_rules", {}) if roster else {}
     windows = (this_start, this_end) if week == "this" else (next_start, next_end)
     plan_all = plan_relevant_games_and_markets(roster, ((this_start, this_end), (next_start, next_end)), regions=region, cache_mode=eff_mode)

--- a/sleeper_api.py
+++ b/sleeper_api.py
@@ -112,6 +112,79 @@ def get_league_id_for_user(username, season):
     return leagues[0]['league_id'], user_id
 
 
+def get_league(league_id):
+    """
+    Fetch a Sleeper league's own metadata directly by ID -- no username
+    needed. Notably includes `status` ("pre_draft" | "drafting" |
+    "in_season" | "complete", per Sleeper's API), which is the actual
+    source of truth for whether a league has drafted yet, and its own
+    `scoring_settings`/`season` (a league_id is season-specific in Sleeper,
+    so there's no separate "season" input required once you have one).
+    """
+    url = f"{SLEEPER_BASE_URL}/league/{league_id}"
+    response = requests.get(url, timeout=REQ_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_league_teams(league_id):
+    """
+    Return one entry per roster in the league, for a "pick your team"
+    selector: {roster_id, owner_id, team_name, display_name}. team_name is
+    whatever the owner set for their team (falls back to their Sleeper
+    display name, then to a generic "Team N" if neither is set).
+    """
+    rosters = get_league_rosters(league_id)
+    users = get_league_users(league_id)
+    display_name_by_owner = {u.get('user_id'): (u.get('display_name') or u.get('username')) for u in (users or [])}
+
+    teams = []
+    for r in (rosters or []):
+        owner_id = r.get('owner_id')
+        display_name = display_name_by_owner.get(owner_id)
+        team_name = (r.get('metadata') or {}).get('team_name') or display_name or f"Team {r.get('roster_id')}"
+        teams.append({
+            "roster_id": r.get('roster_id'),
+            "owner_id": owner_id,
+            "team_name": team_name,
+            "display_name": display_name,
+        })
+    teams.sort(key=lambda t: (t["roster_id"] is None, t["roster_id"]))
+    return teams
+
+
+def get_league_roster_data(league_id, roster_id=None):
+    """
+    League-id-first equivalent of get_user_sleeper_data(username, season):
+    returns the same {'players': ..., 'scoring_rules': ...} shape (so
+    existing consumers don't need to change), plus league metadata that
+    only makes sense once you're not deriving everything from a username --
+    'status', 'season', 'name'.
+
+    If `roster_id` is None (no team picked yet -- e.g. still on the "pick
+    your team" step), 'players' is an empty dict; scoring_rules/status/etc.
+    are still populated, since those are useful (e.g. for the draft board)
+    even before a specific team is chosen.
+    """
+    league = get_league(league_id)
+    scoring_settings = league.get('scoring_settings', {}) or {}
+
+    enhanced_roster = {}
+    if roster_id is not None:
+        rosters = get_league_rosters(league_id)
+        roster = next((r for r in (rosters or []) if r.get('roster_id') == roster_id), None)
+        if roster:
+            enhanced_roster = get_enhanced_info_for_roster(roster)
+
+    return {
+        'players': enhanced_roster,
+        'scoring_rules': scoring_settings,
+        'status': league.get('status'),
+        'season': league.get('season'),
+        'name': league.get('name'),
+    }
+
+
 def get_players(fresh: bool = False):
     """Fetch all NFL player metadata from Sleeper with simple disk cache.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,6 +155,43 @@ class ApiTestCase(unittest.TestCase):
         # positions query param should be parsed into a list and passed through
         self.assertEqual(mock_board.call_args.kwargs.get('positions'), ['QB', 'RB'])
 
+    @patch('refactored.api.resolve_league')
+    def test_league_resolve(self, mock_resolve):
+        mock_resolve.return_value = {
+            'league_id': '123',
+            'name': 'My League',
+            'season': '2026',
+            'status': 'pre_draft',
+            'teams': [{'roster_id': 1, 'owner_id': 'u1', 'team_name': 'Alice', 'display_name': 'Alice'}],
+        }
+        status, headers, payload = wsgi_get('/league/resolve?league_id=123')
+        self.assertTrue(status.startswith('200'))
+        self.assertEqual(payload['status'], 'pre_draft')
+        self.assertEqual(len(payload['teams']), 1)
+
+    def test_league_resolve_requires_league_id(self):
+        status, headers, payload = wsgi_get('/league/resolve')
+        self.assertTrue(status.startswith('400'))
+
+    @patch('refactored.api.resolve_league')
+    def test_league_resolve_not_found(self, mock_resolve):
+        mock_resolve.return_value = {'error': 'league_not_found', 'league_id': 'bogus'}
+        status, headers, payload = wsgi_get('/league/resolve?league_id=bogus')
+        self.assertTrue(status.startswith('404'))
+
+    @patch('refactored.api.list_defenses')
+    @patch('refactored.api.build_lineup')
+    @patch('refactored.api.compute_projections')
+    def test_lineup_passes_league_id_and_roster_id_through(self, mock_proj, mock_build, mock_defs):
+        mock_proj.return_value = {'players': [], 'ratelimit': 'remaining=90%'}
+        mock_defs.return_value = {'defenses': []}
+        mock_build.return_value = {'target': 'mid', 'lineup': [], 'total_points': 0}
+        wsgi_get('/lineup?league_id=LEAGUE123&roster_id=5&week=this&target=mid')
+        self.assertEqual(mock_proj.call_args.kwargs.get('league_id'), 'LEAGUE123')
+        self.assertEqual(mock_proj.call_args.kwargs.get('roster_id'), 5)
+        self.assertEqual(mock_defs.call_args.kwargs.get('league_id'), 'LEAGUE123')
+        self.assertEqual(mock_defs.call_args.kwargs.get('roster_id'), 5)
+
     def test_not_found(self):
         status, headers, payload = wsgi_get('/nope')
         self.assertTrue(status.startswith('404'))

--- a/tests/test_sleeper_league.py
+++ b/tests/test_sleeper_league.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+import sleeper_api
+
+
+def _fake_response(payload):
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class GetLeagueTest(unittest.TestCase):
+    @patch("sleeper_api.requests.get")
+    def test_returns_raw_league_object(self, mock_get):
+        mock_get.return_value = _fake_response({
+            "league_id": "123",
+            "status": "pre_draft",
+            "season": "2026",
+            "name": "My League",
+            "scoring_settings": {"rec": 1.0},
+        })
+        league = sleeper_api.get_league("123")
+        self.assertEqual(league["status"], "pre_draft")
+        self.assertEqual(league["name"], "My League")
+        called_url = mock_get.call_args[0][0]
+        self.assertIn("/league/123", called_url)
+
+
+class GetLeagueTeamsTest(unittest.TestCase):
+    @patch("sleeper_api.get_league_users")
+    @patch("sleeper_api.get_league_rosters")
+    def test_team_name_falls_back_through_metadata_then_display_name_then_generic(self, mock_rosters, mock_users):
+        mock_rosters.return_value = [
+            {"roster_id": 1, "owner_id": "u1", "metadata": {"team_name": "The Custom Name"}},
+            {"roster_id": 2, "owner_id": "u2", "metadata": {}},
+            {"roster_id": 3, "owner_id": "u3"},  # no metadata key at all
+        ]
+        mock_users.return_value = [
+            {"user_id": "u1", "display_name": "Alice"},
+            {"user_id": "u2", "display_name": "Bob"},
+            # u3 has no matching user entry
+        ]
+        teams = sleeper_api.get_league_teams("123")
+        by_roster = {t["roster_id"]: t for t in teams}
+        self.assertEqual(by_roster[1]["team_name"], "The Custom Name")
+        self.assertEqual(by_roster[2]["team_name"], "Bob")
+        self.assertEqual(by_roster[3]["team_name"], "Team 3")
+
+
+class GetLeagueRosterDataTest(unittest.TestCase):
+    @patch("sleeper_api.get_league")
+    def test_no_roster_id_returns_empty_players_but_real_scoring(self, mock_league):
+        mock_league.return_value = {
+            "status": "pre_draft", "season": "2026", "name": "My League",
+            "scoring_settings": {"rec": 0.5},
+        }
+        data = sleeper_api.get_league_roster_data("123", roster_id=None)
+        self.assertEqual(data["players"], {})
+        self.assertEqual(data["scoring_rules"], {"rec": 0.5})
+        self.assertEqual(data["status"], "pre_draft")
+
+    @patch("sleeper_api.get_enhanced_info_for_roster")
+    @patch("sleeper_api.get_league_rosters")
+    @patch("sleeper_api.get_league")
+    def test_roster_id_scopes_to_that_roster_only(self, mock_league, mock_rosters, mock_enhanced):
+        mock_league.return_value = {"status": "in_season", "season": "2026", "name": "L", "scoring_settings": {}}
+        mock_rosters.return_value = [
+            {"roster_id": 1, "players": ["p1"]},
+            {"roster_id": 2, "players": ["p2"]},
+        ]
+        mock_enhanced.return_value = {"p2": {"name": {"full": "Player Two"}}}
+
+        data = sleeper_api.get_league_roster_data("123", roster_id=2)
+        self.assertEqual(data["players"], {"p2": {"name": {"full": "Player Two"}}})
+        mock_enhanced.assert_called_once_with({"roster_id": 2, "players": ["p2"]})
+
+
+class ResolveIdentityPriorityTest(unittest.TestCase):
+    """When both a league_id and a username/season are available, league_id
+    must win -- it's explicit and unambiguous, whereas username-based
+    resolution silently guesses "first league for this user" and can pick
+    the wrong league for anyone in more than one."""
+
+    @patch("refactored.services.sleeper_api.get_user_sleeper_data")
+    @patch("refactored.services.sleeper_api.get_league_roster_data")
+    def test_league_id_takes_priority_over_username(self, mock_league_roster, mock_user_data):
+        from refactored.services import _resolve_identity
+        mock_league_roster.return_value = {"players": {}, "scoring_rules": {"rec": 1.0}}
+        result = _resolve_identity("someuser", "2025", league_id="LEAGUE123", roster_id=5)
+        mock_league_roster.assert_called_once_with("LEAGUE123", roster_id=5)
+        mock_user_data.assert_not_called()
+        self.assertEqual(result["scoring_rules"], {"rec": 1.0})
+
+    @patch("refactored.services.sleeper_api.get_user_sleeper_data")
+    @patch("refactored.services.sleeper_api.get_league_roster_data")
+    def test_falls_back_to_username_when_no_league_id(self, mock_league_roster, mock_user_data):
+        from refactored.services import _resolve_identity
+        mock_user_data.return_value = {"players": {}, "scoring_rules": {"pass_td": 4.0}}
+        result = _resolve_identity("someuser", "2025")
+        mock_user_data.assert_called_once_with("someuser", "2025")
+        mock_league_roster.assert_not_called()
+        self.assertEqual(result["scoring_rules"], {"pass_td": 4.0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/details.js
+++ b/ui/details.js
@@ -210,7 +210,7 @@ function _renderFpVisual(floor, mid, ceil) {
 function openCompareCurves(week) {
   try {
     showDetails('Compare Curves', '<div class="status"><span class="spinner"></span> Loading curves...</div>');
-  var projUrl = apiUrl('/projections', { username: val('username') || 'wesnicol', season: val('season') || '2025', week: week, mode: getDataMode(), model: (typeof getModel==='function'? getModel() : ((document.getElementById('modelSelect') && document.getElementById('modelSelect').value) || 'const')) });
+  var projUrl = apiUrl('/projections', { ...identityParams(), week: week, mode: getDataMode(), model: (typeof getModel==='function'? getModel() : ((document.getElementById('modelSelect') && document.getElementById('modelSelect').value) || 'const')) });
     fetchJSON(projUrl).then(function(res){
       if (!res.ok) { hideDetails(); alert('Failed to load projections'); return; }
       var all = (res.data && res.data.players) || [];
@@ -597,8 +597,7 @@ function openBookCoverage(initialWeek) {
       }
       wrap.innerHTML = '<div class="status"><span class="spinner"></span> Loading coverage...</div>';
       var params = {
-        username: (typeof val === 'function' ? (val('username') || 'wesnicol') : 'wesnicol'),
-        season: (typeof val === 'function' ? (val('season') || '2025') : '2025'),
+        ...identityParams(),
         week: w,
         mode: (typeof getDataMode === 'function' ? getDataMode() : 'auto'),
         model: (typeof getModel === 'function' ? getModel() : 'const')
@@ -864,8 +863,7 @@ async function openPlayerDetails(name, week, opts) {
   }
   // Fetch odds detail + projections for fantasy points trio
   var oddsUrl = apiUrl('/player/odds', {
-    username: val('username') || 'wesnicol',
-    season: val('season') || '2025',
+    ...identityParams(),
     week: week,
     name: name,
     region: 'us,us2',
@@ -873,8 +871,7 @@ async function openPlayerDetails(name, week, opts) {
     model: (document.getElementById('modelSelect') && document.getElementById('modelSelect').value) || 'const'
   });
   var projUrl = apiUrl('/projections', {
-    username: val('username') || 'wesnicol',
-    season: val('season') || '2025',
+    ...identityParams(),
     week: week,
     mode: getDataMode(),
     model: (document.getElementById('modelSelect') && document.getElementById('modelSelect').value) || 'const'
@@ -1177,8 +1174,7 @@ function _renderDebugStatDetail(data, mkey) {
       try {
         var st = (history && history.state) || {};
         var oddsUrlB = apiUrl('/player/odds', {
-          username: val('username') || 'wesnicol',
-          season: val('season') || '2025',
+          ...identityParams(),
           week: (st && st.week) || 'this',
           name: (data && data.player && data.player.name) || '',
           region: 'us,us2',
@@ -1218,8 +1214,7 @@ function _renderDebugStatDetail(data, mkey) {
         try {
           var st = (history && history.state) || {};
           var oddsUrl = apiUrl('/player/odds', {
-            username: val('username') || 'wesnicol',
-            season: val('season') || '2025',
+            ...identityParams(),
             week: (st && st.week) || 'this',
             name: (data && data.player && data.player.name) || '',
             region: 'us,us2',
@@ -1412,8 +1407,7 @@ function _renderStatGraph(title, baseKey, m, summaryThreshold, bookPoints) {
 async function openDefenseDetails(defense, week) {
   showDetails('Defense Details', '<div class="status"><span class="spinner"></span> Loading...</div>');
   var url = apiUrl('/defense/odds', {
-    username: val('username') || 'wesnicol',
-    season: val('season') || '2025',
+    ...identityParams(),
     week: week,
     defense: defense,
     region: 'us,us2',

--- a/ui/index.html
+++ b/ui/index.html
@@ -10,11 +10,13 @@
   <header>
     <h1>Odds Fantasy Dashboard</h1>
     <div class="controls">
-      <label>
+      <span id="leagueIndicator" class="status hidden"></span>
+      <button id="btnChangeLeague" type="button">League / Team</button>
+      <label title="Only used when no league is configured -- click 'League / Team' above instead">
         Username:
         <input id="username" type="text" value="wesnicol" />
       </label>
-      <label>
+      <label title="Only used when no league is configured -- click 'League / Team' above instead">
         Season:
         <input id="season" type="text" value="2025" />
       </label>
@@ -140,6 +142,42 @@
   </div>
 
   
+  <!-- League/team setup overlay -->
+  <div id="leagueSetupOverlay" class="overlay hidden">
+    <div class="overlay-box details-box">
+      <div class="details-header">
+        <div class="details-title">Set Up Your League</div>
+        <button id="leagueSetupClose" class="close-btn" aria-label="Close">✕</button>
+      </div>
+      <div class="details-body">
+        <div id="leagueStepId">
+          <p>Enter your Sleeper League ID. The app uses this (not your
+          username) to know which league's scoring rules to use and whether
+          it's drafted yet -- a username can belong to more than one league,
+          which a league ID never ambiguously does.</p>
+          <p class="status">Find it in your league's Sleeper URL:
+          sleeper.com/leagues/<b>&lt;league_id&gt;</b>/team</p>
+          <div class="btn-row">
+            <input id="leagueIdInput" type="text" placeholder="e.g. 1191596293294682112" style="min-width:260px;" />
+            <button id="leagueIdContinue" type="button">Continue</button>
+          </div>
+          <div id="leagueIdError" class="status" style="color:#f87171;"></div>
+        </div>
+        <div id="leagueStepTeam" class="hidden">
+          <p id="leagueTeamPrompt">Which team is yours?</p>
+          <div class="btn-row">
+            <select id="leagueTeamSelect" style="min-width:260px;"></select>
+          </div>
+          <div class="btn-row">
+            <button id="leagueTeamBack" type="button">Back</button>
+            <button id="leagueTeamContinue" type="button">Continue</button>
+          </div>
+          <div id="leagueTeamError" class="status" style="color:#f87171;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Details modal overlay -->
   <div id="detailsOverlay" class="overlay hidden">
     <div class="overlay-box details-box">

--- a/ui/script.js
+++ b/ui/script.js
@@ -27,6 +27,145 @@ function _updateNetSpin() {
 function _incNet() { _inflight++; _updateNetSpin(); }
 function _decNet() { _inflight = Math.max(0, _inflight - 1); _updateNetSpin(); }
 
+// --- League/team identity -----------------------------------------------
+// Cookies (not localStorage) per the requested design: league_id/roster_id
+// need to survive across the league-setup modal and be readable by every
+// fetch call site without threading extra state through. `identityParams()`
+// is the single place that decides identity for a request: league_id +
+// roster_id (explicit, unambiguous) win over username/season (legacy
+// fallback -- and username-based Sleeper lookup silently picks "your first
+// league" for that username, which is wrong for anyone in more than one).
+function setCookie(name, value, days) {
+  const maxAge = days ? `; max-age=${days * 24 * 60 * 60}` : '';
+  document.cookie = `${name}=${encodeURIComponent(value)}${maxAge}; path=/; SameSite=Lax`;
+}
+function getCookie(name) {
+  const escaped = name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1');
+  const match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+function deleteCookie(name) {
+  document.cookie = `${name}=; path=/; max-age=0`;
+}
+function identityParams() {
+  const leagueId = getCookie('league_id');
+  const rosterId = getCookie('roster_id');
+  if (leagueId && rosterId) return { league_id: leagueId, roster_id: rosterId };
+  return { username: val('username') || 'wesnicol', season: val('season') || '2025' };
+}
+
+// League setup: paste league ID (cookie'd) -> pick your team from a dropdown
+// (cookie'd) -> the league's own Sleeper `status` decides whether to default
+// to the draft board (pre_draft/drafting) or the weekly lineup view
+// (in_season/complete/anything else).
+const PRE_DRAFT_STATUSES = ['pre_draft', 'drafting'];
+
+function showLeagueSetupModal(opts) {
+  opts = opts || {};
+  $('leagueSetupOverlay').classList.remove('hidden');
+  if (opts.step === 'team' && opts._resolvedData) {
+    populateTeamPicker(opts._resolvedData);
+  } else {
+    $('leagueStepId').classList.remove('hidden');
+    $('leagueStepTeam').classList.add('hidden');
+    $('leagueIdError').textContent = '';
+    const existing = getCookie('league_id');
+    if (existing) $('leagueIdInput').value = existing;
+  }
+}
+
+function hideLeagueSetupModal() {
+  $('leagueSetupOverlay').classList.add('hidden');
+}
+
+async function submitLeagueId() {
+  const leagueId = ($('leagueIdInput').value || '').trim();
+  const errEl = $('leagueIdError');
+  errEl.textContent = '';
+  if (!leagueId) { errEl.textContent = 'Please enter a league ID.'; return; }
+  errEl.textContent = 'Looking up league...';
+  const { ok, data } = await fetchJSON(apiUrl('/league/resolve', { league_id: leagueId }));
+  if (!ok || data.error) {
+    errEl.textContent = "Couldn't find that league -- double check the ID from your Sleeper league URL.";
+    return;
+  }
+  errEl.textContent = '';
+  setCookie('league_id', leagueId, 365);
+  populateTeamPicker(data);
+}
+
+function populateTeamPicker(leagueData) {
+  $('leagueStepId').classList.add('hidden');
+  $('leagueStepTeam').classList.remove('hidden');
+  $('leagueTeamError').textContent = '';
+  $('leagueTeamPrompt').textContent = `Which team is yours in "${leagueData.name || 'this league'}"?`;
+  const sel = $('leagueTeamSelect');
+  const teams = leagueData.teams || [];
+  sel.innerHTML = '<option value="">-- Select your team --</option>' +
+    teams.map(t => `<option value="${t.roster_id}">${(t.team_name || ('Team ' + t.roster_id))}</option>`).join('');
+  const existingRoster = getCookie('roster_id');
+  if (existingRoster && teams.some(t => String(t.roster_id) === String(existingRoster))) {
+    sel.value = existingRoster;
+  }
+}
+
+function submitTeamPick() {
+  const sel = $('leagueTeamSelect');
+  if (!sel.value) { $('leagueTeamError').textContent = 'Please pick your team.'; return; }
+  setCookie('roster_id', sel.value, 365);
+  hideLeagueSetupModal();
+  applyResolvedLeagueModeAndRefresh(getCookie('league_id'));
+}
+
+function updateLeagueIndicator(leagueData) {
+  const el = $('leagueIndicator');
+  if (!el) return;
+  const rosterId = getCookie('roster_id');
+  const team = (leagueData.teams || []).find(t => String(t.roster_id) === String(rosterId));
+  const statusLabel = PRE_DRAFT_STATUSES.includes(leagueData.status) ? 'pre-draft' : (leagueData.status || '');
+  el.textContent = `League: ${leagueData.name || leagueData.league_id} | Team: ${team ? team.team_name : '?'} | ${statusLabel}`;
+  el.classList.remove('hidden');
+}
+
+async function applyResolvedLeagueModeAndRefresh(leagueId) {
+  const { ok, data } = await fetchJSON(apiUrl('/league/resolve', { league_id: leagueId }));
+  if (!ok || data.error) {
+    // Stale/broken cookie (e.g. league deleted) -- restart setup from scratch.
+    deleteCookie('league_id');
+    deleteCookie('roster_id');
+    showLeagueSetupModal();
+    return;
+  }
+  updateLeagueIndicator(data);
+  const preSeason = PRE_DRAFT_STATUSES.includes(data.status);
+  dbg('applyResolvedLeagueModeAndRefresh', { status: data.status, preSeason });
+  if (preSeason) {
+    const draftSection = $('draft-board');
+    if (draftSection) draftSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    showDraftBoard('this');
+  } else {
+    refreshAll();
+  }
+}
+
+async function initLeagueFlow() {
+  const leagueId = getCookie('league_id');
+  if (!leagueId) {
+    showLeagueSetupModal();
+    return;
+  }
+  const rosterId = getCookie('roster_id');
+  if (!rosterId) {
+    // League already known but no team picked yet -- resume at step 2
+    // instead of asking for the league ID again.
+    const { ok, data } = await fetchJSON(apiUrl('/league/resolve', { league_id: leagueId }));
+    if (!ok || data.error) { deleteCookie('league_id'); showLeagueSetupModal(); return; }
+    showLeagueSetupModal({ step: 'team', _resolvedData: data });
+    return;
+  }
+  await applyResolvedLeagueModeAndRefresh(leagueId);
+}
+
 function setStatus(el, msg) { if (el) el.textContent = msg || ''; }
 
 function formatRateLimit(info, fallbackStr) {
@@ -154,7 +293,7 @@ async function showLineup(week) {
     const containerId = week === 'this' ? 'lineup-this' : 'lineup-next';
     showContainerLoading(containerId, 'Loading lineup...');
     const mode = getDataMode();
-  const url = apiUrl('/projections', { username: val('username') || 'wesnicol', season: val('season') || '2025', week, mode, model: getModel() });
+  const url = apiUrl('/projections', { ...identityParams(), week, mode, model: getModel() });
     const { ok, data } = await fetchJSON(url);
     if (!ok) { document.getElementById(containerId).innerHTML = '<div class=\"status\">Failed to load lineup.</div>'; return; }
     appCache.lineupPlayers[week] = data.players || [];
@@ -282,7 +421,7 @@ async function loadLineup(week, target) {
     dbg('loadLineup:no-cache', { week, target });
     showContainerLoading(containerId, 'Loading lineup...');
   const mode = getDataMode();
-  const url = apiUrl('/lineup', { username: val('username') || 'wesnicol', season: val('season') || '2025', week, target, mode, model: getModel() });
+  const url = apiUrl('/lineup', { ...identityParams(), week, target, mode, model: getModel() });
     const { ok, data } = await fetchJSON(url);
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load lineup.</div>'; return; }
     appCache.lineups[week] = appCache.lineups[week] || {};
@@ -364,7 +503,7 @@ async function showPlayers(week) {
     dbg('showPlayers:no-cache', { week });
     showContainerLoading(containerId, 'Loading players...');
   const mode = getDataMode();
-  const url = apiUrl('/projections', { username: val('username') || 'wesnicol', season: val('season') || '2025', week, mode, model: getModel() });
+  const url = apiUrl('/projections', { ...identityParams(), week, mode, model: getModel() });
     const { ok, data } = await fetchJSON(url);
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load players.</div>'; return; }
     appCache.projections[week] = data;
@@ -409,7 +548,7 @@ async function showDraftBoard(week) {
     dbg('showDraftBoard:no-cache', { week });
     showContainerLoading(containerId, 'Loading draft board (this can take a bit -- it covers every team playing this week)...');
     const mode = getDataMode();
-    const url = apiUrl('/draft-board', { username: val('username') || 'wesnicol', season: val('season') || '2025', week, mode, model: getModel() });
+    const url = apiUrl('/draft-board', { ...identityParams(), week, mode, model: getModel() });
     const { ok, data } = await fetchJSON(url);
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load draft board.</div>'; return; }
     appCache.draftBoard[week] = data;
@@ -428,7 +567,7 @@ async function loadDefenses(week) {
     dbg('loadDefenses:no-cache', { week });
     showContainerLoading(containerId, 'Loading defenses...');
   const mode = getDataMode();
-  const url = apiUrl('/defenses', { username: val('username') || 'wesnicol', season: val('season') || '2025', week, scope: 'both', mode });
+  const url = apiUrl('/defenses', { ...identityParams(), week, scope: 'both', mode });
     const { ok, data } = await fetchJSON(url);
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load defenses.</div>'; return; }
     appCache.defenses[week] = data;
@@ -441,11 +580,9 @@ async function loadDefenses(week) {
 }
 
 async function refreshAll() {
-  const username = val('username') || 'wesnicol';
-  const season = val('season') || '2025';
   const mode = getDataMode();
-  const url = apiUrl('/dashboard', { username, season, mode, weeks: 'this', def_scope: 'owned', include_players: '1', model: getModel() });
-  dbg('refreshAll:start', { url, username, season });
+  const url = apiUrl('/dashboard', { ...identityParams(), mode, weeks: 'this', def_scope: 'owned', include_players: '1', model: getModel() });
+  dbg('refreshAll:start', { url });
   setStatus($('pingStatus'), 'Refreshing...');
   showGlobalLoading('Refreshing dashboard...');
   disableAllButtons(true);
@@ -488,8 +625,7 @@ async function refreshAll() {
 
 async function dbgProjections(week) {
   const url = apiUrl('/projections', {
-    username: val('username') || 'wesnicol',
-    season: val('season') || '2025',
+    ...identityParams(),
     week,
     mode: getDataMode(),
     model: getModel()
@@ -542,7 +678,26 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   if (btnProjThis) btnProjThis.addEventListener('click', () => dbgProjections('this'));
   if (btnProjNext) btnProjNext.addEventListener('click', () => dbgProjections('next'));
+
+  // League/team setup flow
+  const leagueIdContinue = document.getElementById('leagueIdContinue');
+  if (leagueIdContinue) leagueIdContinue.addEventListener('click', () => submitLeagueId());
+  const leagueIdInput = document.getElementById('leagueIdInput');
+  if (leagueIdInput) leagueIdInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitLeagueId(); });
+  const leagueTeamContinue = document.getElementById('leagueTeamContinue');
+  if (leagueTeamContinue) leagueTeamContinue.addEventListener('click', () => submitTeamPick());
+  const leagueTeamBack = document.getElementById('leagueTeamBack');
+  if (leagueTeamBack) leagueTeamBack.addEventListener('click', () => {
+    document.getElementById('leagueStepTeam').classList.add('hidden');
+    document.getElementById('leagueStepId').classList.remove('hidden');
+  });
+  const leagueSetupClose = document.getElementById('leagueSetupClose');
+  if (leagueSetupClose) leagueSetupClose.addEventListener('click', () => hideLeagueSetupModal());
+  const btnChangeLeague = document.getElementById('btnChangeLeague');
+  if (btnChangeLeague) btnChangeLeague.addEventListener('click', () => showLeagueSetupModal());
+
   dbg('DOMContentLoaded');
+  initLeagueFlow();
   // Click 'Refresh' to load dashboard data when you want to fetch.
   // Global error surfacing for visibility
   window.addEventListener('error', (e) => {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -4,7 +4,8 @@ header { background: #0f172a; color: #fff; padding: 12px 16px; position: sticky;
 h1 { margin: 0 0 8px 0; font-size: 20px; }
 .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
 label { display: inline-flex; align-items: center; gap: 6px; font-size: 14px; }
-input { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
+input, select { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
+.details-body select { background: #0b1020; color: #e2e8f0; border-color: #334155; }
 
 button:hover { background: #0ea5e9; border-color: #0ea5e9; }
 .btn-row { display: flex; gap: 8px; margin: 8px 0; }


### PR DESCRIPTION
## Summary
- Identify "you" by Sleeper league ID + team instead of username -- username-based lookup silently picks "your first league," which is wrong for anyone in more than one.
- `sleeper_api.get_league/get_league_teams/get_league_roster_data`: league-id-first primitives, no username needed. Exposes the league's real `status` field as the source of truth for pre-draft vs. in-season.
- `services._resolve_identity()`: league_id (+roster_id) takes priority over username/season everywhere identity is resolved; falls back to the legacy path when not given, so nothing existing breaks.
- New `GET /league/resolve?league_id=` for the UI's league/team picker.
- UI: blocking first-load modal for league ID (cookie'd) -> team dropdown (cookie'd) -> auto-loads draft board (pre-draft) or weekly dashboard (in-season) based on resolved status. Header indicator + "Change" control.
- 10 new backend tests (Sleeper primitives, identity-resolution priority, new endpoint). 36/36 passing.

## Not verified
No browser available in this environment -- verified via `node --check` on both JS files, an HTML tag-balance check, and the full backend test suite, but the actual modal/dropdown click-through hasn't been exercised in a real browser. Worth doing once deployed.

## Test plan
- [x] `python -m pytest tests/`
- [x] `python -m py_compile` across all modules
- [x] `node --check` on ui/script.js and ui/details.js
- [ ] Click through the league-id -> team-picker -> mode-switch flow in an actual browser
