### PR TITLE
League setup: pick from a dropdown by username, not a pasted ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,27 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the branching model
 (`feature/*` / `dev/*` / `main`) and repo-hygiene rules.
 
 ## League / team identity
-The UI identifies "you" by Sleeper **league ID + team**, not username: on
-first load it prompts for your league ID (stored as a cookie), then a
-dropdown to pick which roster is yours (also cookie'd). This is deliberately
-more precise than username-based lookup, which just grabs "the first league
-this username is in" and silently picks the wrong league for anyone in more
-than one. The league's own Sleeper `status` (`pre_draft`/`drafting` vs.
-`in_season`/`complete`) decides whether the UI defaults to the draft board or
-the weekly lineup view. `GET /league/resolve?league_id=` (status + team list)
-is what powers this; every other endpoint accepts `league_id`+`roster_id` as
-an alternative to `username`+`season`, with `league_id` taking priority when
-both are present (see `services._resolve_identity`). The username/season
-fields still work as a fallback for anyone who hasn't set up a league.
+The UI identifies "you" by Sleeper **league + team**, resolved by league ID
+under the hood (not username) once picked -- but the picking itself starts
+from your Sleeper username, since nobody has their league ID memorized. On
+first load: enter your username (`GET /user/leagues?username=&season=` lists
+every league it finds) -> pick which league (its league_id gets cookie'd) ->
+pick which roster is yours in it (roster_id also cookie'd). This is more
+precise than resolving everything from username alone, which just grabs "the
+first league this username is in" and silently picks the wrong league for
+anyone in more than one -- the username step here is purely a lookup
+convenience, not the identity itself. The chosen league's own Sleeper
+`status` (`pre_draft`/`drafting` vs. `in_season`/`complete`) decides whether
+the UI defaults to the draft board or the weekly lineup view. Every endpoint
+accepts `league_id`+`roster_id` as an alternative to `username`+`season`,
+with `league_id` taking priority when both are present (see
+`services._resolve_identity`). The header's username/season fields still
+work as a fallback for anyone who hasn't set up a league.
 
 ## Project Structure
 - `refactored/`: **This is the real application.** `refactored/api.py` is the
   entrypoint (`CMD` in the `Dockerfile`) — a stdlib WSGI server exposing
-  `/health`, `/league/resolve`, `/projections`, `/lineup`, `/lineup/diffs`,
+  `/health`, `/user/leagues`, `/league/resolve`, `/projections`, `/lineup`, `/lineup/diffs`,
   `/defenses`, `/draft-board`, `/player/odds`, `/defense/odds`, and
   `/dashboard`, and serving the UI under `/` and `/ui/*`. See
   `refactored/services.py` for the orchestration layer,

--- a/config.py
+++ b/config.py
@@ -1,8 +1,29 @@
 import os
+import datetime as _dt
 from dotenv import load_dotenv
 
 # Load environment variables from the .env file
 load_dotenv()
+
+
+def current_nfl_season() -> str:
+    """Best-guess current NFL season year, for defaulting `season` params.
+
+    Sleeper labels a league by the year its season *starts* (e.g. a league
+    playing Sep 2026 -> Jan 2027 has season="2026"). Treat Jan/Feb as still
+    part of the previous season (so a Jan 2027 default doesn't jump ahead
+    to "2027" before that season even exists on Sleeper), March onward as
+    the new one.
+    """
+    now = _dt.datetime.utcnow()
+    year = now.year if now.month >= 3 else now.year - 1
+    return str(year)
+
+
+# A hardcoded "2025" default here would silently go stale every offseason
+# (it did -- this app was still defaulting to 2025 in August 2026). Compute
+# it instead.
+DEFAULT_SEASON = current_nfl_season()
 
 # API configuration for The Odds API
 API_KEY = os.getenv('API_KEY')

--- a/refactored/api.py
+++ b/refactored/api.py
@@ -19,7 +19,8 @@ from typing import Callable
 
 from . import ratelimit
 from . import services  # for detail endpoints
-from .services import compute_projections, compute_book_coverage, build_lineup, build_lineup_diffs, list_defenses, build_dashboard, compute_draft_board, resolve_league
+from .services import compute_projections, compute_book_coverage, build_lineup, build_lineup_diffs, list_defenses, build_dashboard, compute_draft_board, resolve_league, resolve_user_leagues
+from config import DEFAULT_SEASON
 
 # Module-level debug flag (defaults to False). Can be enabled via --debug CLI.
 _DEBUG_FLAG = False
@@ -138,6 +139,18 @@ def application(environ, start_response):
             _dprint("[api] GET /health")
             return _json_response(start_response, "200 OK", {"status": "ok", "ratelimit": ratelimit.format_status(), "ratelimit_info": ratelimit.get_details()})
 
+        if path == "/user/leagues":
+            username = q("username", "")
+            season = q("season", DEFAULT_SEASON)
+            t0 = time.time()
+            _dprint(f"[api] user/leagues username={username} season={season}")
+            if not username:
+                return _json_response(start_response, "400 Bad Request", {"error": "username_required"})
+            data = resolve_user_leagues(username, season)
+            status = "404 Not Found" if data.get("error") else "200 OK"
+            _dprint(f"[api] user/leagues done leagues={len(data.get('leagues', []))} dt={(time.time()-t0):.2f}s")
+            return _json_response(start_response, status, data)
+
         if path == "/league/resolve":
             league_id = q("league_id", "")
             t0 = time.time()
@@ -151,7 +164,7 @@ def application(environ, start_response):
 
         if path == "/projections":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             region = q("region", "us")
             model = q("model", "const")
@@ -166,7 +179,7 @@ def application(environ, start_response):
 
         if path == "/book-coverage":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             region = q("region", "us")
             model = q("model", "const")
@@ -182,7 +195,7 @@ def application(environ, start_response):
 
         if path == "/lineup":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             target = q("target", "mid")
             region = q("region", "us")
@@ -202,7 +215,7 @@ def application(environ, start_response):
 
         if path == "/lineup/diffs":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             region = q("region", "us")
             model = q("model", "const")
@@ -221,7 +234,7 @@ def application(environ, start_response):
 
         if path == "/defenses":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             scope = q("scope", "both")
             region = q("region", "us")
@@ -236,7 +249,7 @@ def application(environ, start_response):
 
         if path == "/player/odds":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             region = q("region", "us")
             name = q("name", "")
@@ -251,7 +264,7 @@ def application(environ, start_response):
 
         if path == "/defense/odds":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             defense = q("defense", "")
             region = q("region", "us")
@@ -264,7 +277,7 @@ def application(environ, start_response):
 
         if path == "/draft-board":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             week = q("week", "this")
             region = q("region", "us")
             model = q("model", "const")
@@ -281,7 +294,7 @@ def application(environ, start_response):
 
         if path == "/dashboard":
             username = q("username", "wesnicol")
-            season = q("season", "2025")
+            season = q("season", DEFAULT_SEASON)
             region = q("region", "us")
             model = q("model", "const")
             fresh = q("fresh", "0") in ("1", "true", "True")
@@ -325,6 +338,7 @@ def main():
 Starting Odds Fantasy API
 Endpoints:
   GET /health
+  GET /user/leagues?username=&season=  (leagues for a Sleeper username, for the league picker)
   GET /league/resolve?league_id=  (status + team list, for the league/team picker)
   GET /projections?username=&season=&week=this|next&fresh=0|1  (or league_id=&roster_id=)
   GET /lineup?username=&season=&week=this|next&target=mid|floor|ceiling&fresh=0|1

--- a/refactored/services.py
+++ b/refactored/services.py
@@ -46,6 +46,39 @@ def _resolve_identity(username: str, season: str, league_id: Optional[str] = Non
     return sleeper_api.get_user_sleeper_data(username, season) or {}
 
 
+def resolve_user_leagues(username: str, season: str) -> Dict:
+    """List a Sleeper user's leagues for a season, for the "pick your
+    league" step of the identity flow. Powered by username (which everyone
+    already knows) rather than requiring you to dig a league ID out of a
+    Sleeper URL -- once a league is picked from this list, `resolve_league`
+    and everything downstream operates on its league_id, not the username.
+    """
+    try:
+        user_id = sleeper_api.get_user_id(username)
+    except Exception as e:
+        print(f"[services] resolve_user_leagues: user lookup failed for {username}: {e}")
+        return {"error": "user_not_found", "username": username}
+    try:
+        leagues = sleeper_api.get_user_leagues(user_id, season)
+    except Exception as e:
+        print(f"[services] resolve_user_leagues: league lookup failed for user_id={user_id}: {e}")
+        leagues = []
+    return {
+        "username": username,
+        "user_id": user_id,
+        "season": season,
+        "leagues": [
+            {
+                "league_id": l.get("league_id"),
+                "name": l.get("name"),
+                "status": l.get("status"),
+                "season": l.get("season"),
+            }
+            for l in (leagues or [])
+        ],
+    }
+
+
 def resolve_league(league_id: str) -> Dict:
     """Given a Sleeper league ID, return everything the UI needs to drive
     the "paste your league ID -> pick your team" flow:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,6 +155,28 @@ class ApiTestCase(unittest.TestCase):
         # positions query param should be parsed into a list and passed through
         self.assertEqual(mock_board.call_args.kwargs.get('positions'), ['QB', 'RB'])
 
+    @patch('refactored.api.resolve_user_leagues')
+    def test_user_leagues(self, mock_resolve):
+        mock_resolve.return_value = {
+            'username': 'wesnicol',
+            'user_id': 'u1',
+            'season': '2026',
+            'leagues': [{'league_id': '123', 'name': 'My League', 'status': 'pre_draft', 'season': '2026'}],
+        }
+        status, headers, payload = wsgi_get('/user/leagues?username=wesnicol&season=2026')
+        self.assertTrue(status.startswith('200'))
+        self.assertEqual(len(payload['leagues']), 1)
+
+    def test_user_leagues_requires_username(self):
+        status, headers, payload = wsgi_get('/user/leagues')
+        self.assertTrue(status.startswith('400'))
+
+    @patch('refactored.api.resolve_user_leagues')
+    def test_user_leagues_not_found(self, mock_resolve):
+        mock_resolve.return_value = {'error': 'user_not_found', 'username': 'nobody'}
+        status, headers, payload = wsgi_get('/user/leagues?username=nobody')
+        self.assertTrue(status.startswith('404'))
+
     @patch('refactored.api.resolve_league')
     def test_league_resolve(self, mock_resolve):
         mock_resolve.return_value = {

--- a/tests/test_sleeper_league.py
+++ b/tests/test_sleeper_league.py
@@ -83,6 +83,52 @@ class GetLeagueRosterDataTest(unittest.TestCase):
         mock_enhanced.assert_called_once_with({"roster_id": 2, "players": ["p2"]})
 
 
+class ResolveUserLeaguesTest(unittest.TestCase):
+    @patch("refactored.services.sleeper_api.get_user_leagues")
+    @patch("refactored.services.sleeper_api.get_user_id")
+    def test_returns_trimmed_league_list(self, mock_user_id, mock_leagues):
+        from refactored.services import resolve_user_leagues
+        mock_user_id.return_value = "u123"
+        mock_leagues.return_value = [
+            {"league_id": "L1", "name": "Dynasty Dudes", "status": "in_season", "season": "2026", "extra_junk": True},
+            {"league_id": "L2", "name": "Redraft Rivals", "status": "pre_draft", "season": "2026"},
+        ]
+        result = resolve_user_leagues("wesnicol", "2026")
+        self.assertEqual(result["user_id"], "u123")
+        self.assertEqual(len(result["leagues"]), 2)
+        self.assertEqual(result["leagues"][0], {"league_id": "L1", "name": "Dynasty Dudes", "status": "in_season", "season": "2026"})
+        mock_leagues.assert_called_once_with("u123", "2026")
+
+    @patch("refactored.services.sleeper_api.get_user_id")
+    def test_unknown_username_returns_error_not_exception(self, mock_user_id):
+        from refactored.services import resolve_user_leagues
+        mock_user_id.side_effect = Exception("404 not found")
+        result = resolve_user_leagues("nobody", "2026")
+        self.assertEqual(result["error"], "user_not_found")
+
+    @patch("refactored.services.sleeper_api.get_user_leagues")
+    @patch("refactored.services.sleeper_api.get_user_id")
+    def test_no_leagues_for_season_returns_empty_list_not_error(self, mock_user_id, mock_leagues):
+        from refactored.services import resolve_user_leagues
+        mock_user_id.return_value = "u123"
+        mock_leagues.return_value = []
+        result = resolve_user_leagues("wesnicol", "2019")
+        self.assertNotIn("error", result)
+        self.assertEqual(result["leagues"], [])
+
+
+class CurrentNflSeasonTest(unittest.TestCase):
+    def test_current_season_matches_expected_default(self):
+        # Sanity check against the real clock rather than hardcoding a
+        # brittle expected year -- just verify the Jan/Feb-is-still-last-
+        # season rule is actually applied.
+        import config
+        now = __import__("datetime").datetime.utcnow()
+        expected = str(now.year if now.month >= 3 else now.year - 1)
+        self.assertEqual(config.current_nfl_season(), expected)
+        self.assertEqual(config.DEFAULT_SEASON, expected)
+
+
 class ResolveIdentityPriorityTest(unittest.TestCase):
     """When both a league_id and a username/season are available, league_id
     must win -- it's explicit and unambiguous, whereas username-based

--- a/ui/index.html
+++ b/ui/index.html
@@ -150,18 +150,25 @@
         <button id="leagueSetupClose" class="close-btn" aria-label="Close">✕</button>
       </div>
       <div class="details-body">
-        <div id="leagueStepId">
-          <p>Enter your Sleeper League ID. The app uses this (not your
-          username) to know which league's scoring rules to use and whether
-          it's drafted yet -- a username can belong to more than one league,
-          which a league ID never ambiguously does.</p>
-          <p class="status">Find it in your league's Sleeper URL:
-          sleeper.com/leagues/<b>&lt;league_id&gt;</b>/team</p>
+        <div id="leagueStepUser">
+          <p>Enter your Sleeper username to find your leagues.</p>
           <div class="btn-row">
-            <input id="leagueIdInput" type="text" placeholder="e.g. 1191596293294682112" style="min-width:260px;" />
-            <button id="leagueIdContinue" type="button">Continue</button>
+            <input id="leagueUsernameInput" type="text" placeholder="Sleeper username" style="min-width:200px;" />
+            <input id="leagueSeasonInput" type="text" placeholder="Season" style="width:90px;" title="NFL season year, e.g. 2026" />
+            <button id="leagueUserContinue" type="button">Continue</button>
           </div>
-          <div id="leagueIdError" class="status" style="color:#f87171;"></div>
+          <div id="leagueUserError" class="status" style="color:#f87171;"></div>
+        </div>
+        <div id="leagueStepLeague" class="hidden">
+          <p id="leagueLeaguePrompt">Which league?</p>
+          <div class="btn-row">
+            <select id="leagueLeagueSelect" style="min-width:280px;"></select>
+          </div>
+          <div class="btn-row">
+            <button id="leagueLeagueBack" type="button">Back</button>
+            <button id="leagueLeagueContinue" type="button">Continue</button>
+          </div>
+          <div id="leagueLeagueError" class="status" style="color:#f87171;"></div>
         </div>
         <div id="leagueStepTeam" class="hidden">
           <p id="leagueTeamPrompt">Which team is yours?</p>

--- a/ui/script.js
+++ b/ui/script.js
@@ -54,48 +54,98 @@ function identityParams() {
   return { username: val('username') || 'wesnicol', season: val('season') || '2025' };
 }
 
-// League setup: paste league ID (cookie'd) -> pick your team from a dropdown
-// (cookie'd) -> the league's own Sleeper `status` decides whether to default
-// to the draft board (pre_draft/drafting) or the weekly lineup view
-// (in_season/complete/anything else).
+// League setup, 3 steps: enter Sleeper username (cookie'd) -> pick which of
+// your leagues (its league_id gets cookie'd) -> pick your team in it
+// (roster_id cookie'd). The league's own Sleeper `status` then decides
+// whether to default to the draft board (pre_draft/drafting) or the weekly
+// lineup view (in_season/complete/anything else). Username here is only
+// ever used to list leagues to choose from -- once a league_id is picked,
+// everything downstream is keyed off league_id+roster_id, not username.
 const PRE_DRAFT_STATUSES = ['pre_draft', 'drafting'];
 
-function showLeagueSetupModal(opts) {
-  opts = opts || {};
+function currentNflSeason() {
+  // Mirrors config.current_nfl_season() in Python: Sleeper labels a league
+  // by the year its season starts, and Jan/Feb still belongs to last season.
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  return String((now.getUTCMonth() + 1) >= 3 ? y : y - 1);
+}
+
+function _openLeagueOverlay() {
   $('leagueSetupOverlay').classList.remove('hidden');
-  if (opts.step === 'team' && opts._resolvedData) {
-    populateTeamPicker(opts._resolvedData);
-  } else {
-    $('leagueStepId').classList.remove('hidden');
-    $('leagueStepTeam').classList.add('hidden');
-    $('leagueIdError').textContent = '';
-    const existing = getCookie('league_id');
-    if (existing) $('leagueIdInput').value = existing;
-  }
 }
 
 function hideLeagueSetupModal() {
   $('leagueSetupOverlay').classList.add('hidden');
 }
 
-async function submitLeagueId() {
-  const leagueId = ($('leagueIdInput').value || '').trim();
-  const errEl = $('leagueIdError');
+function showLeagueSetupModal() {
+  _openLeagueOverlay();
+  $('leagueStepUser').classList.remove('hidden');
+  $('leagueStepLeague').classList.add('hidden');
+  $('leagueStepTeam').classList.add('hidden');
+  $('leagueUserError').textContent = '';
+  const existingUser = getCookie('sleeper_username');
+  if (existingUser) $('leagueUsernameInput').value = existingUser;
+  const seasonInput = $('leagueSeasonInput');
+  if (seasonInput && !seasonInput.value) seasonInput.value = currentNflSeason();
+}
+
+async function submitUsername() {
+  const username = ($('leagueUsernameInput').value || '').trim();
+  const season = ($('leagueSeasonInput').value || '').trim() || currentNflSeason();
+  const errEl = $('leagueUserError');
   errEl.textContent = '';
-  if (!leagueId) { errEl.textContent = 'Please enter a league ID.'; return; }
-  errEl.textContent = 'Looking up league...';
-  const { ok, data } = await fetchJSON(apiUrl('/league/resolve', { league_id: leagueId }));
+  if (!username) { errEl.textContent = 'Please enter your Sleeper username.'; return; }
+  errEl.textContent = 'Looking up leagues...';
+  const { ok, data } = await fetchJSON(apiUrl('/user/leagues', { username, season }));
   if (!ok || data.error) {
-    errEl.textContent = "Couldn't find that league -- double check the ID from your Sleeper league URL.";
+    errEl.textContent = "Couldn't find that Sleeper username -- double check the spelling.";
+    return;
+  }
+  if (!data.leagues || !data.leagues.length) {
+    errEl.textContent = `No leagues found for "${username}" in ${season}. Try a different season above.`;
     return;
   }
   errEl.textContent = '';
-  setCookie('league_id', leagueId, 365);
+  setCookie('sleeper_username', username, 365);
+  populateLeaguePicker(data);
+}
+
+function populateLeaguePicker(leaguesData) {
+  _openLeagueOverlay();
+  $('leagueStepUser').classList.add('hidden');
+  $('leagueStepLeague').classList.remove('hidden');
+  $('leagueStepTeam').classList.add('hidden');
+  $('leagueLeagueError').textContent = '';
+  $('leagueLeaguePrompt').textContent = `Which league, ${leaguesData.username}?`;
+  const sel = $('leagueLeagueSelect');
+  const leagues = leaguesData.leagues || [];
+  sel.innerHTML = '<option value="">-- Select a league --</option>' +
+    leagues.map(l => `<option value="${l.league_id}">${(l.name || l.league_id)} (${l.status || 'unknown status'})</option>`).join('');
+  const existingLeague = getCookie('league_id');
+  if (existingLeague && leagues.some(l => String(l.league_id) === String(existingLeague))) {
+    sel.value = existingLeague;
+  }
+}
+
+async function submitLeaguePick() {
+  const sel = $('leagueLeagueSelect');
+  const errEl = $('leagueLeagueError');
+  errEl.textContent = '';
+  if (!sel.value) { errEl.textContent = 'Please pick a league.'; return; }
+  errEl.textContent = 'Loading teams...';
+  const { ok, data } = await fetchJSON(apiUrl('/league/resolve', { league_id: sel.value }));
+  if (!ok || data.error) { errEl.textContent = 'Failed to load that league. Try again.'; return; }
+  errEl.textContent = '';
+  setCookie('league_id', sel.value, 365);
   populateTeamPicker(data);
 }
 
 function populateTeamPicker(leagueData) {
-  $('leagueStepId').classList.add('hidden');
+  _openLeagueOverlay();
+  $('leagueStepUser').classList.add('hidden');
+  $('leagueStepLeague').classList.add('hidden');
   $('leagueStepTeam').classList.remove('hidden');
   $('leagueTeamError').textContent = '';
   $('leagueTeamPrompt').textContent = `Which team is yours in "${leagueData.name || 'this league'}"?`;
@@ -151,16 +201,28 @@ async function applyResolvedLeagueModeAndRefresh(leagueId) {
 async function initLeagueFlow() {
   const leagueId = getCookie('league_id');
   if (!leagueId) {
+    // No league picked yet. If we already know the username (e.g. picked a
+    // league before but never finished team selection, or cleared just the
+    // league_id cookie), skip straight to the league list instead of
+    // asking for the username again.
+    const savedUsername = getCookie('sleeper_username');
+    if (savedUsername) {
+      const { ok, data } = await fetchJSON(apiUrl('/user/leagues', { username: savedUsername, season: currentNflSeason() }));
+      if (ok && !data.error && data.leagues && data.leagues.length) {
+        populateLeaguePicker(data);
+        return;
+      }
+    }
     showLeagueSetupModal();
     return;
   }
   const rosterId = getCookie('roster_id');
   if (!rosterId) {
-    // League already known but no team picked yet -- resume at step 2
-    // instead of asking for the league ID again.
+    // League already known but no team picked yet -- resume at the team
+    // step instead of starting over.
     const { ok, data } = await fetchJSON(apiUrl('/league/resolve', { league_id: leagueId }));
     if (!ok || data.error) { deleteCookie('league_id'); showLeagueSetupModal(); return; }
-    showLeagueSetupModal({ step: 'team', _resolvedData: data });
+    populateTeamPicker(data);
     return;
   }
   await applyResolvedLeagueModeAndRefresh(leagueId);
@@ -679,18 +741,30 @@ document.addEventListener('DOMContentLoaded', () => {
   if (btnProjThis) btnProjThis.addEventListener('click', () => dbgProjections('this'));
   if (btnProjNext) btnProjNext.addEventListener('click', () => dbgProjections('next'));
 
-  // League/team setup flow
-  const leagueIdContinue = document.getElementById('leagueIdContinue');
-  if (leagueIdContinue) leagueIdContinue.addEventListener('click', () => submitLeagueId());
-  const leagueIdInput = document.getElementById('leagueIdInput');
-  if (leagueIdInput) leagueIdInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitLeagueId(); });
+  // League/team setup flow: username -> league -> team
+  const leagueUserContinue = document.getElementById('leagueUserContinue');
+  if (leagueUserContinue) leagueUserContinue.addEventListener('click', () => submitUsername());
+  const leagueUsernameInput = document.getElementById('leagueUsernameInput');
+  if (leagueUsernameInput) leagueUsernameInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitUsername(); });
+  const leagueSeasonInput = document.getElementById('leagueSeasonInput');
+  if (leagueSeasonInput) leagueSeasonInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitUsername(); });
+
+  const leagueLeagueContinue = document.getElementById('leagueLeagueContinue');
+  if (leagueLeagueContinue) leagueLeagueContinue.addEventListener('click', () => submitLeaguePick());
+  const leagueLeagueBack = document.getElementById('leagueLeagueBack');
+  if (leagueLeagueBack) leagueLeagueBack.addEventListener('click', () => {
+    document.getElementById('leagueStepLeague').classList.add('hidden');
+    document.getElementById('leagueStepUser').classList.remove('hidden');
+  });
+
   const leagueTeamContinue = document.getElementById('leagueTeamContinue');
   if (leagueTeamContinue) leagueTeamContinue.addEventListener('click', () => submitTeamPick());
   const leagueTeamBack = document.getElementById('leagueTeamBack');
   if (leagueTeamBack) leagueTeamBack.addEventListener('click', () => {
     document.getElementById('leagueStepTeam').classList.add('hidden');
-    document.getElementById('leagueStepId').classList.remove('hidden');
+    document.getElementById('leagueStepLeague').classList.remove('hidden');
   });
+
   const leagueSetupClose = document.getElementById('leagueSetupClose');
   if (leagueSetupClose) leagueSetupClose.addEventListener('click', () => hideLeagueSetupModal());
   const btnChangeLeague = document.getElementById('btnChangeLeague');


### PR DESCRIPTION
## Summary
- Modal is now 3 steps: username+season -> league dropdown (new `GET /user/leagues`) -> team dropdown. No more digging a league ID out of a URL.
- Username is only used for the lookup step -- the cookie'd identity is still `league_id`+`roster_id`, so the "username can belong to multiple leagues" ambiguity this whole feature exists to fix stays fixed.
- Username also gets cookie'd so "Change League" resumes at the league list, not from scratch.
- Bonus fix found along the way: every `season` default was hardcoded `"2025"`, stale as of August 2026 -- would have made the new username lookup silently return zero leagues by default. `config.current_nfl_season()` computes it instead.
- 7 new tests. 43/43 passing.

## Test plan
- [x] `python -m pytest tests/`
- [x] `python -m py_compile` across all modules
- [x] `node --check` on both modified JS files
- [x] HTML tag-balance check
- [ ] Click through the actual username -> league -> team flow in a browser (still not available in this environment)
