### PR TITLE
Simplify the UI: adaptive 2-panel layout

### DIFF
--- a/ui/details.js
+++ b/ui/details.js
@@ -1614,63 +1614,49 @@ document.addEventListener('DOMContentLoaded', function(){
     });
   }
 
-  function attachNameHandler(containerId, nameColIndex, week) {
-    var el = document.getElementById(containerId); if (!el) return;
-    el.addEventListener('click', function(e){
-      var td = e.target.closest('td'); if (!td) return;
-      if (td.cellIndex !== nameColIndex) return;
-      var nameEl = td.querySelector('.player-name'); var name = nameEl ? (nameEl.getAttribute('data-player') || nameEl.textContent || '').trim() : (td.textContent || '').trim(); if (!name) return;
-      openPlayerDetails(name, week);
-    });
-  }
-  attachNameHandler('lineup-this', 1, 'this');
-  attachNameHandler('lineup-next', 1, 'next');
-  attachNameHandler('players-this', 0, 'this');
-  attachNameHandler('players-next', 0, 'next');
-
-  // Also allow clicking Floor/Mid/Ceiling cells to open player details
-  function attachPlayerStatHandler(containerId, week, cols) {
-    var el = document.getElementById(containerId); if (!el) return;
-    el.addEventListener('click', function(e){
-      var td = e.target.closest('td'); if (!td) return;
-      if (!cols.includes(td.cellIndex)) return;
-      // Find the name cell in the same row depending on table layout
-      var tr = td.parentElement; if (!tr) return;
-      // Try typical layouts: lineup: name at index 1; players: name at index 0
-      var nameCell = tr.cells[1] || tr.cells[0]; var nameEl = nameCell ? nameCell.querySelector('.player-name') : null; var name = nameEl ? (nameEl.getAttribute('data-player') || nameEl.textContent || '').trim() : ((nameCell && nameCell.textContent) || '').trim(); if (!name) return;
-      // Determine week from containerId suffix
-      openPlayerDetails(name, week);
-    });
-  }
-  // lineup tables: columns [3,4,5] ; players tables: [2,3,4]
-  attachPlayerStatHandler('lineup-this', 'this', [3,4,5]);
-  attachPlayerStatHandler('lineup-next', 'next', [3,4,5]);
-  attachPlayerStatHandler('players-this', 'this', [2,3,4]);
-  attachPlayerStatHandler('players-next', 'next', [2,3,4]);
-
-  function attachDefenseHandler(containerId, week) {
+  // The main UI now has ONE results container per panel (#weekly-results,
+  // shared across the Lineup/All Players/Defenses views; #draft-board) that
+  // gets re-rendered in place as the week/view toggles change, instead of
+  // one static container per week. So rather than binding a handler per old
+  // per-week container with a hardcoded week, bind one delegated handler per
+  // container that reads the CURRENT week/view from script.js's small
+  // accessor globals at click time. Matching by the `.player-name` marker
+  // (present in every row renderLineup/renderPlayers produce) instead of a
+  // fixed column index also means this doesn't care whether the row it
+  // clicked came from the lineup table or the players table.
+  function attachWeeklyResultsHandler(containerId, getWeek, getView) {
     var el = document.getElementById(containerId); if (!el) return;
     el.addEventListener('click', function(e){
       var td = e.target.closest('td'); if (!td) return;
       var tr = td.parentElement; if (!tr) return;
-      // Allow clicking defense name (col 0) or implied median (col 3)
-      if (td.cellIndex === 0 || td.cellIndex === 3) {
-        var def = (tr.cells[0] && tr.cells[0].textContent || td.textContent || '').trim(); if (!def) return;
+      var week = (typeof getWeek === 'function' && getWeek()) || 'this';
+      var view = (typeof getView === 'function' && getView()) || 'lineup';
+      if (view === 'defenses') {
+        if (td.cellIndex !== 0 && td.cellIndex !== 3) return;
+        var def = (tr.cells[0] && tr.cells[0].textContent || '').trim(); if (!def) return;
+        e.stopPropagation();
         openDefenseDetails(def, week);
+        return;
       }
+      var nameEl = tr.querySelector('.player-name');
+      var name = nameEl ? (nameEl.getAttribute('data-player') || nameEl.textContent || '').trim() : '';
+      if (!name) return;
+      e.stopPropagation();
+      openPlayerDetails(name, week);
     });
   }
-  attachDefenseHandler('defenses-this', 'this');
-  attachDefenseHandler('defenses-next', 'next');
+  attachWeeklyResultsHandler('weekly-results', window.getCurrentWeeklyWeek, window.getCurrentWeeklyView);
+  attachWeeklyResultsHandler('draft-board', window.getCurrentDraftWeek, function () { return 'lineup'; });
 
-  // Global fallback: clicking any .player-name opens details (covers future tables)
+  // Global fallback for any other .player-name click (e.g. inside the
+  // Compare Curves / Book Coverage modals) that the handler above didn't
+  // already claim via stopPropagation.
   try {
     document.addEventListener('click', function(e){
       var el = e.target.closest('.player-name');
       if (!el) return;
       var name = (el.getAttribute('data-player') || el.textContent || '').trim();
       if (!name) return;
-      // Default to 'this' week when unknown
       openPlayerDetails(name, 'this');
     });
   } catch (e) {}

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,130 +8,116 @@
 </head>
 <body>
   <header>
-    <h1>Odds Fantasy Dashboard</h1>
+    <h1>Odds Fantasy</h1>
     <div class="controls">
       <span id="leagueIndicator" class="status hidden"></span>
-      <button id="btnChangeLeague" type="button">League / Team</button>
-      <label title="Only used when no league is configured -- click 'League / Team' above instead">
-        Username:
-        <input id="username" type="text" value="wesnicol" />
-      </label>
-      <label title="Only used when no league is configured -- click 'League / Team' above instead">
-        Season:
-        <input id="season" type="text" value="2025" />
-      </label>
-      <span>Data:</span>
-      <label><input type="radio" name="dataMode" value="auto" checked /> Auto (TTL)</label>
-      <label><input type="radio" name="dataMode" value="cache" /> Cache</label>
-      <label><input type="radio" name="dataMode" value="fresh" /> Fresh</label>
-      <label>
-        Model:
-        <select id="modelSelect">
-          <option value="const" selected>Constantini</option>
-          <option value="puelz">Puelz</option>
-          <option value="angelini">Angelini</option>
-          <option value="baseline">Baseline</option>
-        </select>
-      </label>
-      <span id="pingStatus" class="status"></span>
+      <button id="btnChangeLeague" type="button">Change</button>
       <span id="rlHeader" class="status"></span>
       <span id="netSpin" class="spinner hidden" title="Network activity"></span>
+      <button id="btnSettings" type="button" aria-label="Settings" title="Settings">&#9881;</button>
     </div>
   </header>
 
-  <main>
-    <section class="coverage-entry">
-      <h2>Book Coverage</h2>
-      <div class="btn-row">
-        <button id="btnBookCoverage">Show Book Coverage</button>
-      </div>
-    </section>
-
-    <section>
-      <h2>Lineups - This Week</h2><div class="btn-row"><button data-week="this" class="btn-compare-curves">Show Lineup</button></div><div id="lineup-this" class="results"></div>
-    </section>
-
-    <section>
-      <h2>Lineups - Next Week</h2><div class="btn-row"><button data-week="next" class="btn-compare-curves">Show Lineup</button></div><div id="lineup-next" class="results"></div>
-    </section>
-
-    <section>
-      <h2>Defenses - This Week</h2>
-      <div class="btn-row">
-        <button data-week="this" class="btn-defenses">Load Defenses (Owned + Available)</button>
-      </div>
-      <div id="defenses-this" class="results"></div>
-    </section>
-
-    <section>
-      <h2>Defenses - Next Week</h2>
-      <div class="btn-row">
-        <button data-week="next" class="btn-defenses">Load Defenses (Owned + Available)</button>
-      </div>
-      <div id="defenses-next" class="results"></div>
-    </section>
-
-    <section>
-      <h2>Raw Projections (Debug)</h2>
-      <div class="btn-row">
-        <button id="btnProjThis">Fetch Projections (This Week)</button>
-        <button id="btnProjNext">Fetch Projections (Next Week)</button>
-      </div>
-      <pre id="projectionsDebug" class="debug"></pre>
-    </section>
-
-    <section>
-      <h2>Draft Board (Pre-Season / All Players)</h2>
-      <p class="status">Not scoped to your roster -- every active QB/RB/WR/TE
-      on a team playing the selected week. "Week 1" / "Week 2" are anchored to
-      the earliest games found in the odds feed, not today's date (a draft
-      happens once, before the season, so "today" isn't a useful anchor the
-      way it is for the weekly lineup views below) -- the loaded date range
-      is shown once you load a week. This is a single week's market-implied
-      outlook, not a full-season projection: a real, useful signal for
-      role/opportunity, but not a replacement for season-long ADP/rankings.
-      Uses a smaller set of markets than the weekly views to limit Odds API
-      usage; only fetch this when you actually need it (see CONTRIBUTING.md).</p>
-      <div class="btn-row">
-        <button data-week="this" class="btn-draft-board">Load Week 1</button>
-        <button data-week="next" class="btn-draft-board">Load Week 2</button>
-      </div>
-      <div id="draft-board" class="results"></div>
-    </section>
-
-    <section>
-      <h2>Players - This Week</h2>
-      <div class="btn-row">
-        <button data-week="this" class="btn-players">Show Players</button>
-      </div>
-      <div id="players-this" class="results"></div>
-    </section>
-
-    <section>
-      <h2>Players - Next Week</h2>
-      <div class="btn-row">
-        <button data-week="next" class="btn-players">Show Players</button>
-      </div>
-      <div id="players-next" class="results"></div>
-    </section>
-  </main>
-
-  <footer>
-    <span id="rateLimit" class="status"></span>
-  </footer>
-
-  <!-- Floating model selector (always visible) -->
-  <div id="floatingModel" class="floating-controls" aria-label="Model selector" title="Choose probability model">
+  <!-- Settings popover: data mode, probability model, and the username/season
+       fallback identity path (only relevant if you skip league setup). -->
+  <div id="settingsPanel" class="settings-panel hidden">
     <label>
-      <span class="fm-label">Model</span>
-      <select id="modelSelectFloating">
+      <span>Data</span>
+      <select id="dataModeSelect">
+        <option value="auto" selected>Auto (TTL cache)</option>
+        <option value="cache">Cache only</option>
+        <option value="fresh">Force fresh</option>
+      </select>
+    </label>
+    <label>
+      <span>Model</span>
+      <select id="modelSelect">
         <option value="const" selected>Constantini</option>
         <option value="puelz">Puelz</option>
         <option value="angelini">Angelini</option>
         <option value="baseline">Baseline</option>
       </select>
     </label>
+    <div class="advanced-fallback">
+      <button id="btnShowFallbackId" type="button">Use username/season instead of a league</button>
+      <div id="fallbackIdFields" class="hidden">
+        <label>
+          <span>Username</span>
+          <input id="username" type="text" value="wesnicol" />
+        </label>
+        <label>
+          <span>Season</span>
+          <input id="season" type="text" value="" />
+        </label>
+        <p class="status">Only used when no league is configured -- click "Change" above to switch back to league mode.</p>
+      </div>
+    </div>
   </div>
+
+  <main>
+    <div class="btn-row mode-switch">
+      <button id="modeDraftBtn" class="toggle-btn" data-mode="draft">Draft Board</button>
+      <button id="modeWeeklyBtn" class="toggle-btn toggle-active" data-mode="weekly">Weekly</button>
+    </div>
+
+    <section id="panel-draft" class="hidden">
+      <p class="status">Every active QB/RB/WR/TE on a team playing the
+      selected week -- not scoped to your roster. "Week 1"/"Week 2" are
+      anchored to the earliest games in the odds feed, not today's date. A
+      single week's market-implied outlook, not a season-long projection.</p>
+      <div class="btn-row">
+        <button data-week="this" class="toggle-btn week-toggle toggle-active">Week 1</button>
+        <button data-week="next" class="toggle-btn week-toggle">Week 2</button>
+        <select id="draftPosFilter">
+          <option value="">All positions</option>
+          <option value="QB">QB</option>
+          <option value="RB">RB</option>
+          <option value="WR">WR</option>
+          <option value="TE">TE</option>
+        </select>
+      </div>
+      <div id="draft-board" class="results"></div>
+    </section>
+
+    <section id="panel-weekly">
+      <div class="btn-row">
+        <button data-week="this" class="toggle-btn week-toggle toggle-active">This Week</button>
+        <button data-week="next" class="toggle-btn week-toggle">Next Week</button>
+      </div>
+      <div class="btn-row">
+        <button data-view="lineup" class="toggle-btn view-toggle toggle-active">Lineup</button>
+        <button data-view="players" class="toggle-btn view-toggle">All Players</button>
+        <button data-view="defenses" class="toggle-btn view-toggle">Defenses</button>
+      </div>
+      <div class="btn-row" id="targetToggleRow">
+        <button data-target="floor" class="toggle-btn target-toggle">Floor</button>
+        <button data-target="mid" class="toggle-btn target-toggle toggle-active">Mid</button>
+        <button data-target="ceiling" class="toggle-btn target-toggle">Ceiling</button>
+      </div>
+      <div id="weekly-results" class="results"></div>
+    </section>
+
+    <div class="btn-row">
+      <button id="btnToggleAdvanced" type="button">Show Advanced Tools</button>
+    </div>
+    <section id="panel-advanced" class="hidden">
+      <h2>Advanced</h2>
+      <div class="btn-row">
+        <button id="btnBookCoverage">Book Coverage</button>
+        <button data-week="this" class="btn-compare-curves">Compare Curves (This Week)</button>
+        <button data-week="next" class="btn-compare-curves">Compare Curves (Next Week)</button>
+      </div>
+      <div class="btn-row">
+        <button id="btnProjThis">Raw Projections (This Week)</button>
+        <button id="btnProjNext">Raw Projections (Next Week)</button>
+      </div>
+      <pre id="projectionsDebug" class="debug"></pre>
+    </section>
+  </main>
+
+  <footer>
+    <span id="rateLimit" class="status"></span>
+  </footer>
 
   <!-- Global loading overlay -->
   <div id="globalLoading" class="overlay hidden">
@@ -141,7 +127,6 @@
     </div>
   </div>
 
-  
   <!-- League/team setup overlay -->
   <div id="leagueSetupOverlay" class="overlay hidden">
     <div class="overlay-box details-box">
@@ -154,7 +139,6 @@
           <p>Enter your Sleeper username to find your leagues.</p>
           <div class="btn-row">
             <input id="leagueUsernameInput" type="text" placeholder="Sleeper username" style="min-width:200px;" />
-            <input id="leagueSeasonInput" type="text" placeholder="Season" style="width:90px;" title="NFL season year, e.g. 2026" />
             <button id="leagueUserContinue" type="button">Continue</button>
           </div>
           <div id="leagueUserError" class="status" style="color:#f87171;"></div>
@@ -209,11 +193,4 @@
 <script src="/ui/script.js"></script>
   <script src="/ui/details.js"></script>
 </body>
-  
 </html>
-
-
-
-
-
-

--- a/ui/script.js
+++ b/ui/script.js
@@ -1,11 +1,11 @@
-﻿// Simple debug logger
+// Simple debug logger
 const DEBUG = true; // toggle to enable/disable UI debug logs
 function dbg(...args) { if (DEBUG && console && console.log) console.log('[ui]', ...args); }
 
 function $(id) { return document.getElementById(id); }
 function val(id) { return ($(id) ? $(id).value : '').trim(); }
 
-// In-memory cache for preloaded data
+// In-memory cache for preloaded data, keyed the same way the API is: by week.
 const appCache = {
   lineups: { this: {}, next: {} },
   defenses: { this: null, next: null },
@@ -13,9 +13,6 @@ const appCache = {
   draftBoard: { this: null, next: null },
   lastRateLimit: null,
 };
-// Store raw players for local lineup building
-appCache.lineupPlayers = { this: null, next: null };
-const selectedTarget = { this: 'mid', next: 'mid' };
 
 // Track network activity to drive header spinner
 let _inflight = 0;
@@ -51,7 +48,16 @@ function identityParams() {
   const leagueId = getCookie('league_id');
   const rosterId = getCookie('roster_id');
   if (leagueId && rosterId) return { league_id: leagueId, roster_id: rosterId };
-  return { username: val('username') || 'wesnicol', season: val('season') || '2025' };
+  return { username: val('username') || 'wesnicol', season: val('season') || currentNflSeason() };
+}
+
+function currentNflSeason() {
+  // Mirrors config.current_nfl_season() in Python: Sleeper labels a league
+  // by the year its season starts, and Jan/Feb still belongs to last season.
+  // Never shown as a field -- there's no reason to ask the user for this.
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  return String((now.getUTCMonth() + 1) >= 3 ? y : y - 1);
 }
 
 // League setup, 3 steps: enter Sleeper username (cookie'd) -> pick which of
@@ -62,14 +68,6 @@ function identityParams() {
 // ever used to list leagues to choose from -- once a league_id is picked,
 // everything downstream is keyed off league_id+roster_id, not username.
 const PRE_DRAFT_STATUSES = ['pre_draft', 'drafting'];
-
-function currentNflSeason() {
-  // Mirrors config.current_nfl_season() in Python: Sleeper labels a league
-  // by the year its season starts, and Jan/Feb still belongs to last season.
-  const now = new Date();
-  const y = now.getUTCFullYear();
-  return String((now.getUTCMonth() + 1) >= 3 ? y : y - 1);
-}
 
 function _openLeagueOverlay() {
   $('leagueSetupOverlay').classList.remove('hidden');
@@ -87,13 +85,11 @@ function showLeagueSetupModal() {
   $('leagueUserError').textContent = '';
   const existingUser = getCookie('sleeper_username');
   if (existingUser) $('leagueUsernameInput').value = existingUser;
-  const seasonInput = $('leagueSeasonInput');
-  if (seasonInput && !seasonInput.value) seasonInput.value = currentNflSeason();
 }
 
 async function submitUsername() {
   const username = ($('leagueUsernameInput').value || '').trim();
-  const season = ($('leagueSeasonInput').value || '').trim() || currentNflSeason();
+  const season = currentNflSeason();
   const errEl = $('leagueUserError');
   errEl.textContent = '';
   if (!username) { errEl.textContent = 'Please enter your Sleeper username.'; return; }
@@ -104,7 +100,7 @@ async function submitUsername() {
     return;
   }
   if (!data.leagues || !data.leagues.length) {
-    errEl.textContent = `No leagues found for "${username}" in ${season}. Try a different season above.`;
+    errEl.textContent = `No leagues found for "${username}" in ${season}.`;
     return;
   }
   errEl.textContent = '';
@@ -173,7 +169,7 @@ function updateLeagueIndicator(leagueData) {
   const rosterId = getCookie('roster_id');
   const team = (leagueData.teams || []).find(t => String(t.roster_id) === String(rosterId));
   const statusLabel = PRE_DRAFT_STATUSES.includes(leagueData.status) ? 'pre-draft' : (leagueData.status || '');
-  el.textContent = `League: ${leagueData.name || leagueData.league_id} | Team: ${team ? team.team_name : '?'} | ${statusLabel}`;
+  el.textContent = `${leagueData.name || leagueData.league_id} · ${team ? team.team_name : '?'} · ${statusLabel}`;
   el.classList.remove('hidden');
 }
 
@@ -189,13 +185,7 @@ async function applyResolvedLeagueModeAndRefresh(leagueId) {
   updateLeagueIndicator(data);
   const preSeason = PRE_DRAFT_STATUSES.includes(data.status);
   dbg('applyResolvedLeagueModeAndRefresh', { status: data.status, preSeason });
-  if (preSeason) {
-    const draftSection = $('draft-board');
-    if (draftSection) draftSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    showDraftBoard('this');
-  } else {
-    refreshAll();
-  }
+  setMode(preSeason ? 'draft' : 'weekly');
 }
 
 async function initLeagueFlow() {
@@ -246,7 +236,11 @@ function updateRateLimitDisplays(payload) {
   setStatus($('rlHeader'), str);
 }
 
-// Build lineup locally from projections
+// Build a lineup client-side from an already-fetched player list. Used only
+// by the Compare Curves modal's LINEUP tab (details.js) as a preview, not by
+// the primary Lineup view (which calls the server-authoritative /lineup
+// endpoint -- see refreshWeeklyView -- so it correctly includes DEF and
+// matches what /lineup/diffs compares against).
 function computeLineupFromPlayers(players, target) {
   const buckets = { QB: [], RB: [], WR: [], TE: [] };
   for (const p of (players || [])) {
@@ -323,49 +317,6 @@ function computeLineupFromPlayers(players, target) {
   return { target: targetKey, lineup, total_points: Number(total.toFixed(2)) };
 }
 
-
-
-function renderLineupFromPlayers(week) {
-  const players = appCache.lineupPlayers[week] || [];
-  const target = selectedTarget[week] || 'mid';
-  const payload = computeLineupFromPlayers(players, target);
-  const containerId = week === 'this' ? 'lineup-this' : 'lineup-next';
-  const title = week === 'this' ? 'This Week Lineup' : 'Next Week Lineup';
-  renderLineup(containerId, title, payload);
-  addLineupControls(week, 'players', target);
-  // Make headers clickable to switch target
-  const c = document.getElementById(containerId);
-  if (!c) return;
-  c.querySelectorAll('th').forEach(th => {
-    const txt = (th.textContent || '').toLowerCase();
-    if (['floor','mid','ceiling'].some(k => txt.includes(k))) {
-      th.style.cursor = 'pointer';
-      th.onclick = () => {
-        if (txt.includes('floor')) selectedTarget[week] = 'floor';
-        else if (txt.includes('mid')) selectedTarget[week] = 'mid';
-        else if (txt.includes('ceiling')) selectedTarget[week] = 'ceiling';
-        renderLineupFromPlayers(week);
-      };
-    }
-  });
-}
-
-async function showLineup(week) {
-  if (!appCache.lineupPlayers[week]) {
-    const containerId = week === 'this' ? 'lineup-this' : 'lineup-next';
-    showContainerLoading(containerId, 'Loading lineup...');
-    const mode = getDataMode();
-  const url = apiUrl('/projections', { ...identityParams(), week, mode, model: getModel() });
-    const { ok, data } = await fetchJSON(url);
-    if (!ok) { document.getElementById(containerId).innerHTML = '<div class=\"status\">Failed to load lineup.</div>'; return; }
-    appCache.lineupPlayers[week] = data.players || [];
-    appCache.lastRateLimit = data;
-    selectedTarget[week] = 'mid';
-  }
-  renderLineupFromPlayers(week);
-  updateRateLimitDisplays(appCache.lastRateLimit || {});
-}
-
 // UI loading helpers
 function disableAllButtons(disabled) {
   document.querySelectorAll('button').forEach(btn => { btn.disabled = !!disabled; });
@@ -409,18 +360,14 @@ function apiUrl(path, params = {}) {
 }
 
 function getDataMode() {
-  const el = document.querySelector('md-radio[name="dataMode"][checked]') || document.querySelector('input[name="dataMode"]:checked');
-  if (!el) return 'auto';
-  return el.value || el.getAttribute('value') || 'auto';
+  const el = $('dataModeSelect');
+  return (el && el.value) ? el.value : 'auto';
 }
 
 function getModel() {
-  const elFloat = document.getElementById('modelSelectFloating');
-  if (elFloat && elFloat.value) return elFloat.value;
-  const el = document.getElementById('modelSelect');
+  const el = $('modelSelect');
   return (el && el.value) ? el.value : 'const';
 }
-
 
 function renderLineup(containerId, title, payload) {
   const c = $(containerId);
@@ -447,6 +394,7 @@ function renderLineup(containerId, title, payload) {
     `<div class="status">RateLimit: ${ratelimit}</div>`
   ].join('\n');
   c.innerHTML = table;
+  try { enableTableSort(c.querySelector('table')); } catch (e) {}
 }
 
 function renderDefenses(containerId, payload) {
@@ -457,44 +405,22 @@ function renderDefenses(containerId, payload) {
     c.innerHTML = '<div class="status">No defenses found for this week.</div>';
     return;
   }
-  // Ensure sorted by opponent implied total ascending (server already sorts, but keep safe)
   rows.sort((a, b) => (Number(a.implied_total_median) - Number(b.implied_total_median)) || (Number(b.book_count) - Number(a.book_count)));
   const table = [
-    '<table><thead><tr><th>Defense</th><th>Owner</th><th>Opponent</th><th>Game Date</th><th>Opp Implied</th><th># Books</th><th>Source</th></tr></thead><tbody>',
+    '<table><thead><tr><th>Defense</th><th>Owner</th><th>Opponent</th><th>Game Date</th><th>Opp Implied</th><th>Floor</th><th>Mid</th><th>Ceiling</th></tr></thead><tbody>',
     ...rows.map(r => {
       const owner = r.owner ? String(r.owner) : '';
       const mine = !!r.owned_by_current;
       const taken = !!(r.owner);
       const cls = mine ? 'def-row def-mine' : (taken ? 'def-row def-taken' : 'def-row def-available');
-      return `<tr class="${cls}"><td>${r.defense}</td><td>${owner || '-'}</td><td>${r.opponent}</td><td>${r.game_date}</td><td>${Number(r.implied_total_median).toFixed(2)}</td><td>${r.book_count}</td><td>${r.source}</td></tr>`;
+      const fmt = (v) => (v == null ? '-' : Number(v).toFixed(2));
+      return `<tr class="${cls}"><td>${r.defense}</td><td>${owner || '-'}</td><td>${r.opponent}</td><td>${r.game_date}</td><td>${fmt(r.implied_total_median)}</td><td>${fmt(r.floor)}</td><td>${fmt(r.mid)}</td><td>${fmt(r.ceiling)}</td></tr>`;
     }),
     '</tbody></table>',
     `<div class="status">RateLimit: ${payload.ratelimit || ''}</div>`
   ].join('\n');
   c.innerHTML = table;
-}
-
-async function loadLineup(week, target) {
-  // Use cached data preloaded on refresh
-  const cached = appCache.lineups?.[week]?.[target];
-  const containerId = week === 'this' ? 'lineup-this' : 'lineup-next';
-  const title = week === 'this' ? 'This Week Lineup' : 'Next Week Lineup';
-  if (!cached) {
-    dbg('loadLineup:no-cache', { week, target });
-    showContainerLoading(containerId, 'Loading lineup...');
-  const mode = getDataMode();
-  const url = apiUrl('/lineup', { ...identityParams(), week, target, mode, model: getModel() });
-    const { ok, data } = await fetchJSON(url);
-    if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load lineup.</div>'; return; }
-    appCache.lineups[week] = appCache.lineups[week] || {};
-    appCache.lineups[week][target] = data;
-    renderLineup(containerId, title, data);
-    updateRateLimitDisplays(data);
-    return;
-  }
-  renderLineup(containerId, title, cached);
-  addLineupControls(week, 'api', target);
-  updateRateLimitDisplays(appCache.lastRateLimit || cached);
+  try { enableTableSort(c.querySelector('table')); } catch (e) {}
 }
 
 function renderPlayers(containerId, players) {
@@ -504,7 +430,6 @@ function renderPlayers(containerId, players) {
     c.innerHTML = '<div class="status">No players found.</div>';
     return;
   }
-  // Sort by mid descending
   rows.sort((a, b) => Number(b.mid || 0) - Number(a.mid || 0));
   const table = [
     '<table><thead><tr><th>Name</th><th>Pos</th><th>Floor</th><th>Mid</th><th>Ceiling</th></tr></thead><tbody>',
@@ -512,70 +437,61 @@ function renderPlayers(containerId, players) {
     '</tbody></table>'
   ].join('\n');
   c.innerHTML = table;
+  try { enableTableSort(c.querySelector('table')); } catch (e) {}
 }
 
-// Inject lineup controls (Refresh, Close) into container
-function addLineupControls(week, source, target) {
-  try {
-    const containerId = week === 'this' ? 'lineup-this' : 'lineup-next';
-    const c = $(containerId);
-    if (!c) return;
-    // Remove existing controls to avoid duplicates
-    const old = c.querySelector('.lineup-controls');
-    if (old && old.parentNode) old.parentNode.removeChild(old);
-    const controls = document.createElement('div');
-    controls.className = 'btn-row lineup-controls';
-    controls.innerHTML = `
-      <button onclick="window._refreshLineup('${week}','${target||'mid'}','${source||'api'}')">Refresh</button>
-      <button onclick="window._closeLineup('${week}')">Close</button>
-    `;
-    c.insertAdjacentElement('afterbegin', controls);
-  } catch (e) {
-    console.error('[ui] addLineupControls:error', e);
-  }
-}
+// --- Weekly panel (Lineup / All Players / Defenses, This/Next Week) -----
+const weeklyState = { week: 'this', view: 'lineup', target: 'mid' };
+window.getCurrentWeeklyWeek = () => weeklyState.week;
+window.getCurrentWeeklyView = () => weeklyState.view;
 
-// Global helpers used by controls
-window._closeLineup = function(week) {
-  const id = (week === 'this' ? 'lineup-this' : 'lineup-next');
-  const el = $(id);
-  if (el) el.innerHTML = '';
-};
-
-window._refreshLineup = async function(week, target, source) {
-  try {
-    if (source === 'players') {
-      // Force re-fetch projections and re-render local lineup
-      appCache.lineupPlayers[week] = null;
-      await showLineup(week);
-    } else {
-      // Force re-fetch lineup from API by clearing cache
-      if (appCache.lineups[week]) delete appCache.lineups[week][target||'mid'];
-      await loadLineup(week, target||'mid');
-    }
-  } catch (e) {
-    console.error('[ui] _refreshLineup:error', e);
-  }
-};
-
-async function showPlayers(week) {
-  const cached = appCache.projections?.[week];
-  const containerId = week === 'this' ? 'players-this' : 'players-next';
-  if (!cached) {
-    dbg('showPlayers:no-cache', { week });
-    showContainerLoading(containerId, 'Loading players...');
+async function refreshWeeklyView() {
+  const { week, view, target } = weeklyState;
+  const containerId = 'weekly-results';
   const mode = getDataMode();
-  const url = apiUrl('/projections', { ...identityParams(), week, mode, model: getModel() });
-    const { ok, data } = await fetchJSON(url);
+  const model = getModel();
+
+  if (view === 'lineup') {
+    const cached = appCache.lineups?.[week]?.[target];
+    if (cached) {
+      renderLineup(containerId, week === 'this' ? 'This Week Lineup' : 'Next Week Lineup', cached);
+      updateRateLimitDisplays(cached);
+      return;
+    }
+    showContainerLoading(containerId, 'Loading lineup...');
+    const { ok, data } = await fetchJSON(apiUrl('/lineup', { ...identityParams(), week, target, mode, model }));
+    if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load lineup.</div>'; return; }
+    appCache.lineups[week] = appCache.lineups[week] || {};
+    appCache.lineups[week][target] = data;
+    appCache.lastRateLimit = data;
+    renderLineup(containerId, week === 'this' ? 'This Week Lineup' : 'Next Week Lineup', data);
+    updateRateLimitDisplays(data);
+  } else if (view === 'players') {
+    const cached = appCache.projections?.[week];
+    if (cached) { renderPlayers(containerId, cached.players || []); updateRateLimitDisplays(appCache.lastRateLimit || {}); return; }
+    showContainerLoading(containerId, 'Loading players...');
+    const { ok, data } = await fetchJSON(apiUrl('/projections', { ...identityParams(), week, mode, model }));
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load players.</div>'; return; }
     appCache.projections[week] = data;
+    appCache.lastRateLimit = data;
     renderPlayers(containerId, data.players || []);
     updateRateLimitDisplays(data);
-    return;
+  } else if (view === 'defenses') {
+    const cached = appCache.defenses?.[week];
+    if (cached) { renderDefenses(containerId, cached); updateRateLimitDisplays(appCache.lastRateLimit || cached); return; }
+    showContainerLoading(containerId, 'Loading defenses...');
+    const { ok, data } = await fetchJSON(apiUrl('/defenses', { ...identityParams(), week, scope: 'both', mode }));
+    if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load defenses.</div>'; return; }
+    appCache.defenses[week] = data;
+    appCache.lastRateLimit = data;
+    renderDefenses(containerId, data);
+    updateRateLimitDisplays(data);
   }
-  renderPlayers(containerId, cached.players || []);
-  updateRateLimitDisplays(appCache.lastRateLimit || {});
 }
+
+// --- Draft board panel (Week 1 / Week 2, position filter) ----------------
+const draftState = { week: 'this' };
+window.getCurrentDraftWeek = () => draftState.week;
 
 function _renderDraftBoard(containerId, data) {
   // "Week 1"/"Week 2" are schedule-anchored (earliest games in the odds
@@ -583,7 +499,9 @@ function _renderDraftBoard(containerId, data) {
   // (or the "nothing scheduled yet" message) so it's never ambiguous what's
   // actually loaded. renderPlayers() owns the table itself; this just adds
   // a header in front of it.
-  renderPlayers(containerId, data.players || []);
+  const posFilter = ($('draftPosFilter') || {}).value || '';
+  const players = posFilter ? (data.players || []).filter(p => p.pos === posFilter) : (data.players || []);
+  renderPlayers(containerId, players);
   const c = $(containerId);
   if (!c) return;
   let header = '';
@@ -601,19 +519,22 @@ function _renderDraftBoard(containerId, data) {
 
 async function showDraftBoard(week) {
   // Intentionally not scoped to any roster -- see /draft-board in the API
-  // and CONTRIBUTING.md's "Odds API quota awareness" section. Only fetched
-  // on click, and cached per-week client-side so re-toggling doesn't
-  // re-hit the API.
+  // and CONTRIBUTING.md's "Odds API quota awareness" section. Fetched once
+  // per week and cached client-side; the position filter re-filters the
+  // cached board instead of re-fetching (the API doesn't fetch fewer games
+  // for a narrower position filter, so there's no cost benefit to a
+  // server round-trip on every filter change).
+  draftState.week = week;
   const cached = appCache.draftBoard?.[week];
   const containerId = 'draft-board';
   if (!cached) {
     dbg('showDraftBoard:no-cache', { week });
     showContainerLoading(containerId, 'Loading draft board (this can take a bit -- it covers every team playing this week)...');
-    const mode = getDataMode();
-    const url = apiUrl('/draft-board', { ...identityParams(), week, mode, model: getModel() });
+    const url = apiUrl('/draft-board', { ...identityParams(), week, mode: getDataMode(), model: getModel() });
     const { ok, data } = await fetchJSON(url);
     if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load draft board.</div>'; return; }
     appCache.draftBoard[week] = data;
+    appCache.lastRateLimit = data;
     _renderDraftBoard(containerId, data);
     updateRateLimitDisplays(data);
     return;
@@ -622,76 +543,33 @@ async function showDraftBoard(week) {
   updateRateLimitDisplays(appCache.lastRateLimit || {});
 }
 
-async function loadDefenses(week) {
-  const cached = appCache.defenses?.[week];
-  const containerId = week === 'this' ? 'defenses-this' : 'defenses-next';
-  if (!cached) {
-    dbg('loadDefenses:no-cache', { week });
-    showContainerLoading(containerId, 'Loading defenses...');
-  const mode = getDataMode();
-  const url = apiUrl('/defenses', { ...identityParams(), week, scope: 'both', mode });
-    const { ok, data } = await fetchJSON(url);
-    if (!ok) { $(containerId).innerHTML = '<div class="status">Failed to load defenses.</div>'; return; }
-    appCache.defenses[week] = data;
-    renderDefenses(containerId, data);
-    updateRateLimitDisplays(data);
-    return;
-  }
-  renderDefenses(containerId, cached);
-  updateRateLimitDisplays(appCache.lastRateLimit || cached);
+// --- Mode switch (Draft Board vs Weekly) ----------------------------------
+function setMode(mode) {
+  const isDraft = mode === 'draft';
+  $('panel-draft').classList.toggle('hidden', !isDraft);
+  $('panel-weekly').classList.toggle('hidden', isDraft);
+  $('modeDraftBtn').classList.toggle('toggle-active', isDraft);
+  $('modeWeeklyBtn').classList.toggle('toggle-active', !isDraft);
+  if (isDraft) showDraftBoard(draftState.week);
+  else refreshWeeklyView();
 }
 
-async function refreshAll() {
-  const mode = getDataMode();
-  const url = apiUrl('/dashboard', { ...identityParams(), mode, weeks: 'this', def_scope: 'owned', include_players: '1', model: getModel() });
-  dbg('refreshAll:start', { url });
-  setStatus($('pingStatus'), 'Refreshing...');
-  showGlobalLoading('Refreshing dashboard...');
-  disableAllButtons(true);
-  try {
-    const { ok, data } = await fetchJSON(url);
-    if (!ok) throw new Error('Request failed: ' + url);
-    // Populate cache
-    appCache.lineups.this.mid = data?.lineups?.this?.mid || null;
-    appCache.lineups.this.floor = data?.lineups?.this?.floor || null;
-    appCache.lineups.this.ceiling = data?.lineups?.this?.ceiling || null;
-    appCache.lineups.next.mid = data?.lineups?.next?.mid || null;
-    appCache.lineups.next.floor = data?.lineups?.next?.floor || null;
-    appCache.lineups.next.ceiling = data?.lineups?.next?.ceiling || null;
-    appCache.defenses.this = data?.defenses?.this || null;
-    appCache.defenses.next = data?.defenses?.next || null;
-    appCache.projections.this = data?.projections?.this || null;
-    appCache.projections.next = data?.projections?.next || null;
-    appCache.lastRateLimit = data;
-    setStatus($('pingStatus'), 'Ready');
-    dbg('refreshAll:cache-filled', {
-      lineups_this: Object.keys(appCache.lineups.this).length,
-      lineups_next: Object.keys(appCache.lineups.next).length,
-      defenses_this: !!appCache.defenses.this,
-      defenses_next: !!appCache.defenses.next,
-      players_this: (data?.projections?.this?.players || []).length,
-      players_next: (data?.projections?.next?.players || []).length,
-    });
-    // Render defaults
-    loadLineup('this', 'mid');
-    loadDefenses('this');
-  } catch (e) {
-    console.error('[ui] refreshAll:error', e);
-    alert('Refresh failed. Check API base URL and server.');
-    setStatus($('pingStatus'), 'Error');
-  } finally {
-    hideGlobalLoading();
-    disableAllButtons(false);
-  }
+// Refresh whichever panel is currently visible. Also called by details.js
+// after a model change inside a player-detail popup, so it stays meaningful
+// as "refresh the background view under the new model" rather than a no-op.
+function refreshAll() {
+  const draftVisible = !$('panel-draft').classList.contains('hidden');
+  // Invalidate caches so the new model/data-mode actually takes effect.
+  appCache.lineups = { this: {}, next: {} };
+  appCache.defenses = { this: null, next: null };
+  appCache.projections = { this: null, next: null };
+  appCache.draftBoard = { this: null, next: null };
+  if (draftVisible) showDraftBoard(draftState.week);
+  else refreshWeeklyView();
 }
 
 async function dbgProjections(week) {
-  const url = apiUrl('/projections', {
-    ...identityParams(),
-    week,
-    mode: getDataMode(),
-    model: getModel()
-  });
+  const url = apiUrl('/projections', { ...identityParams(), week, mode: getDataMode(), model: getModel() });
   showContainerLoading('projectionsDebug', 'Loading projections...');
   const { ok, data } = await fetchJSON(url);
   if (!ok) { dbg('dbgProjections:fail', { week, url }); return alert('Failed to load projections'); }
@@ -702,78 +580,127 @@ async function dbgProjections(week) {
 // Wire handlers
 document.addEventListener('DOMContentLoaded', () => {
   loadSettings();
-  // Help (More Info) overlay wiring
-  try {
-    const btnHelp = document.getElementById('btnHelp');
-    const help = document.getElementById('helpOverlay');
-    const helpClose = document.getElementById('helpClose');
-    if (btnHelp && help) {
-      btnHelp.addEventListener('click', () => { try { help.classList.remove('hidden'); } catch (e) {} });
-    }
-    if (helpClose && help) {
-      helpClose.addEventListener('click', () => { try { help.classList.add('hidden'); } catch (e) {} });
-    }
-  } catch (e) { /* ignore */ }
   attachSettingsListeners();
-  try { const v = getModel(); const ms = document.getElementById('modelSelect'); const mf = document.getElementById('modelSelectFloating'); if (ms) ms.value = v; if (mf) mf.value = v; } catch (e) {}
-  
-  // Removed: legacy number-only lineup view button
-  document.querySelectorAll('.btn-defenses').forEach(btn => {
-    btn.addEventListener('click', () => loadDefenses(btn.dataset.week));
-  });
+
+  // Settings popover
+  const btnSettings = $('btnSettings');
+  const settingsPanel = $('settingsPanel');
+  if (btnSettings && settingsPanel) {
+    btnSettings.addEventListener('click', (e) => { e.stopPropagation(); settingsPanel.classList.toggle('open'); });
+    document.addEventListener('click', (e) => {
+      if (!settingsPanel.classList.contains('open')) return;
+      if (settingsPanel.contains(e.target) || e.target === btnSettings) return;
+      settingsPanel.classList.remove('open');
+    });
+  }
+  const btnShowFallbackId = $('btnShowFallbackId');
+  const fallbackIdFields = $('fallbackIdFields');
+  if (btnShowFallbackId && fallbackIdFields) {
+    btnShowFallbackId.addEventListener('click', () => fallbackIdFields.classList.toggle('hidden'));
+  }
+
+  // Mode switch
+  const modeDraftBtn = $('modeDraftBtn');
+  const modeWeeklyBtn = $('modeWeeklyBtn');
+  if (modeDraftBtn) modeDraftBtn.addEventListener('click', () => setMode('draft'));
+  if (modeWeeklyBtn) modeWeeklyBtn.addEventListener('click', () => setMode('weekly'));
+
+  // Draft panel toggles
+  const draftPanel = $('panel-draft');
+  if (draftPanel) {
+    draftPanel.querySelectorAll('.week-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        draftPanel.querySelectorAll('.week-toggle').forEach(b => b.classList.toggle('toggle-active', b === btn));
+        showDraftBoard(btn.dataset.week);
+      });
+    });
+  }
+  const draftPosFilter = $('draftPosFilter');
+  if (draftPosFilter) draftPosFilter.addEventListener('change', () => showDraftBoard(draftState.week));
+
+  // Weekly panel toggles
+  const weeklyPanel = $('panel-weekly');
+  if (weeklyPanel) {
+    weeklyPanel.querySelectorAll('.week-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        weeklyState.week = btn.dataset.week;
+        weeklyPanel.querySelectorAll('.week-toggle').forEach(b => b.classList.toggle('toggle-active', b === btn));
+        refreshWeeklyView();
+      });
+    });
+    weeklyPanel.querySelectorAll('.view-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        weeklyState.view = btn.dataset.view;
+        weeklyPanel.querySelectorAll('.view-toggle').forEach(b => b.classList.toggle('toggle-active', b === btn));
+        const targetRow = $('targetToggleRow');
+        if (targetRow) targetRow.classList.toggle('hidden', weeklyState.view !== 'lineup');
+        refreshWeeklyView();
+      });
+    });
+    weeklyPanel.querySelectorAll('.target-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        weeklyState.target = btn.dataset.target;
+        weeklyPanel.querySelectorAll('.target-toggle').forEach(b => b.classList.toggle('toggle-active', b === btn));
+        refreshWeeklyView();
+      });
+    });
+  }
+
+  // Advanced tools (collapsed by default)
+  const btnToggleAdvanced = $('btnToggleAdvanced');
+  const panelAdvanced = $('panel-advanced');
+  if (btnToggleAdvanced && panelAdvanced) {
+    btnToggleAdvanced.addEventListener('click', () => {
+      const nowHidden = panelAdvanced.classList.toggle('hidden');
+      btnToggleAdvanced.textContent = nowHidden ? 'Show Advanced Tools' : 'Hide Advanced Tools';
+    });
+  }
   document.querySelectorAll('.btn-compare-curves').forEach(btn => {
     btn.addEventListener('click', () => {
       try { if (typeof openCompareCurves === 'function') openCompareCurves(btn.dataset.week || 'this'); } catch (e) { console.error(e); }
     });
   });
-  const btnBookCoverage = document.getElementById('btnBookCoverage');
+  const btnBookCoverage = $('btnBookCoverage');
   if (btnBookCoverage) {
     btnBookCoverage.addEventListener('click', () => {
       try { if (typeof openBookCoverage === 'function') openBookCoverage('this'); } catch (e) { console.error(e); }
     });
   }
-  document.querySelectorAll('.btn-players').forEach(btn => {
-    btn.addEventListener('click', () => showPlayers(btn.dataset.week));
-  });
-  document.querySelectorAll('.btn-draft-board').forEach(btn => {
-    btn.addEventListener('click', () => showDraftBoard(btn.dataset.week));
-  });
+  const btnProjThis = $('btnProjThis');
+  const btnProjNext = $('btnProjNext');
   if (btnProjThis) btnProjThis.addEventListener('click', () => dbgProjections('this'));
   if (btnProjNext) btnProjNext.addEventListener('click', () => dbgProjections('next'));
 
   // League/team setup flow: username -> league -> team
-  const leagueUserContinue = document.getElementById('leagueUserContinue');
+  const leagueUserContinue = $('leagueUserContinue');
   if (leagueUserContinue) leagueUserContinue.addEventListener('click', () => submitUsername());
-  const leagueUsernameInput = document.getElementById('leagueUsernameInput');
+  const leagueUsernameInput = $('leagueUsernameInput');
   if (leagueUsernameInput) leagueUsernameInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitUsername(); });
-  const leagueSeasonInput = document.getElementById('leagueSeasonInput');
-  if (leagueSeasonInput) leagueSeasonInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') submitUsername(); });
 
-  const leagueLeagueContinue = document.getElementById('leagueLeagueContinue');
+  const leagueLeagueContinue = $('leagueLeagueContinue');
   if (leagueLeagueContinue) leagueLeagueContinue.addEventListener('click', () => submitLeaguePick());
-  const leagueLeagueBack = document.getElementById('leagueLeagueBack');
+  const leagueLeagueBack = $('leagueLeagueBack');
   if (leagueLeagueBack) leagueLeagueBack.addEventListener('click', () => {
-    document.getElementById('leagueStepLeague').classList.add('hidden');
-    document.getElementById('leagueStepUser').classList.remove('hidden');
+    $('leagueStepLeague').classList.add('hidden');
+    $('leagueStepUser').classList.remove('hidden');
   });
 
-  const leagueTeamContinue = document.getElementById('leagueTeamContinue');
+  const leagueTeamContinue = $('leagueTeamContinue');
   if (leagueTeamContinue) leagueTeamContinue.addEventListener('click', () => submitTeamPick());
-  const leagueTeamBack = document.getElementById('leagueTeamBack');
+  const leagueTeamBack = $('leagueTeamBack');
   if (leagueTeamBack) leagueTeamBack.addEventListener('click', () => {
-    document.getElementById('leagueStepTeam').classList.add('hidden');
-    document.getElementById('leagueStepLeague').classList.remove('hidden');
+    $('leagueStepTeam').classList.add('hidden');
+    $('leagueStepLeague').classList.remove('hidden');
   });
 
-  const leagueSetupClose = document.getElementById('leagueSetupClose');
+  const leagueSetupClose = $('leagueSetupClose');
   if (leagueSetupClose) leagueSetupClose.addEventListener('click', () => hideLeagueSetupModal());
-  const btnChangeLeague = document.getElementById('btnChangeLeague');
+  const btnChangeLeague = $('btnChangeLeague');
   if (btnChangeLeague) btnChangeLeague.addEventListener('click', () => showLeagueSetupModal());
 
   dbg('DOMContentLoaded');
   initLeagueFlow();
-  // Click 'Refresh' to load dashboard data when you want to fetch.
-  // Global error surfacing for visibility
+
   window.addEventListener('error', (e) => {
     console.error('[ui] window.error', e?.error || e?.message || e);
   });
@@ -782,18 +709,14 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-
-
-
-
 // Persist basic settings in localStorage
 function saveSettings() {
   try {
     const data = {
       username: ($('username')||{}).value || '',
       season: ($('season')||{}).value || '',
-      dataMode: (document.querySelector('input[name="dataMode"]:checked')||{}).value || 'auto',
-      model: getModel() || 'const',
+      dataMode: getDataMode(),
+      model: getModel(),
     };
     localStorage.setItem('ofdash.settings', JSON.stringify(data));
   } catch (e) { /* ignore */ }
@@ -806,22 +729,15 @@ function loadSettings() {
     const s = JSON.parse(raw);
     if (s.username && $('username')) $('username').value = s.username;
     if (s.season && $('season')) $('season').value = s.season;
-    if (s.dataMode) {
-      const radio = document.querySelector('input[name="dataMode"][value="'+s.dataMode+'"]');
-      if (radio) radio.checked = true;
-    }
-    if (s.model) {
-      const ms = document.getElementById('modelSelect'); if (ms) ms.value = s.model;
-      const mf = document.getElementById('modelSelectFloating'); if (mf) mf.value = s.model;
-    }
+    if (s.dataMode) { const dm = $('dataModeSelect'); if (dm) dm.value = s.dataMode; }
+    if (s.model) { const ms = $('modelSelect'); if (ms) ms.value = s.model; }
   } catch (e) { /* ignore */ }
 }
 
 function attachSettingsListeners() {
   ['username','season'].forEach(id => { const el=$(id); if (el) el.addEventListener('change', saveSettings); });
-  document.querySelectorAll('input[name="dataMode"]').forEach(r => r.addEventListener('change', saveSettings));
-  const ms = document.getElementById('modelSelect'); if (ms) ms.addEventListener('change', () => { try { const mf = document.getElementById('modelSelectFloating'); if (mf) mf.value = ms.value; saveSettings(); refreshAll(); } catch (e) {} });
-  const mf = document.getElementById('modelSelectFloating'); if (mf) mf.addEventListener('change', () => { try { const ms2 = document.getElementById('modelSelect'); if (ms2) ms2.value = mf.value; saveSettings(); refreshAll(); } catch (e) {} });
+  const dm = $('dataModeSelect'); if (dm) dm.addEventListener('change', () => { saveSettings(); refreshAll(); });
+  const ms = $('modelSelect'); if (ms) ms.addEventListener('change', () => { saveSettings(); refreshAll(); });
 }
 
 // Enable simple table sorting on click
@@ -851,4 +767,3 @@ function enableTableSort(table) {
     });
   } catch (e) { /* ignore */ }
 }
-

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -8,7 +8,24 @@ input, select { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
 .details-body select { background: #0b1020; color: #e2e8f0; border-color: #334155; }
 
 button:hover { background: #0ea5e9; border-color: #0ea5e9; }
-.btn-row { display: flex; gap: 8px; margin: 8px 0; }
+.btn-row { display: flex; gap: 8px; margin: 8px 0; flex-wrap: wrap; align-items: center; }
+
+/* Toggle-button groups (week/view/target/mode switches) */
+.toggle-btn { padding: 6px 14px; border: 1px solid #cbd5e1; border-radius: 999px; background: #fff; cursor: pointer; font-size: 14px; }
+.toggle-btn.toggle-active { background: #0f172a; color: #fff; border-color: #0f172a; }
+.toggle-btn.toggle-active:hover { background: #0f172a; }
+.mode-switch .toggle-btn { font-size: 15px; font-weight: 600; padding: 8px 20px; }
+
+/* Header settings gear + popover */
+#btnSettings { font-size: 16px; line-height: 1; padding: 6px 10px; }
+.settings-panel {
+  position: fixed; top: 56px; right: 16px; z-index: 1200;
+  background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.3); min-width: 260px;
+}
+.settings-panel label { display: flex; justify-content: space-between; align-items: center; gap: 10px; margin-bottom: 8px; }
+.settings-panel .advanced-fallback { margin-top: 10px; padding-top: 10px; border-top: 1px solid #334155; }
+.settings-panel .advanced-fallback label { margin-top: 8px; }
 main { padding: 16px; max-width: 1100px; margin: 0 auto; }
 section { background: #fff; border: 1px solid #e5e7eb; border-radius: 6px; padding: 12px; margin-bottom: 14px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
 .results { margin-top: 8px; overflow-x: auto; }


### PR DESCRIPTION
## Summary
- Replaced 9 always-visible sections + duplicate model selectors with an adaptive 2-panel layout (Draft Board / Weekly, auto-picked from league status) using toggle rows instead of duplicate This/Next sections.
- Removed a dead client-side lineup-rebuild code path that only the model dropdown's change handler ever triggered.
- Advanced tools (Book Coverage, Compare Curves, raw projections dump) moved behind a single collapsed section instead of top-level clutter.
- Dropped the season field from the league setup modal per direct request -- uses the computed current-season default silently.
- details.js's click-to-open-details wiring simplified from 10 hardcoded-week handlers to 2 that read current week/view dynamically -- also fixes a latent bug where the fallback always assumed "this week" regardless of which table was clicked.

## Verification
- [x] `python -m pytest tests/` -- 43/43 (backend untouched)
- [x] `node --check` on both modified JS files
- [x] HTML tag-balance check
- [x] Static id cross-check: every DOM id referenced in script.js/details.js exists in the new index.html (or is created dynamically inside the details modal, confirmed by inspection)
- [ ] Actual browser click-through -- still no browser available in this environment
