### PR TITLE
Fix time-dependent failure in draft-prep planning test

### DIFF
--- a/tests/test_draft_prep.py
+++ b/tests/test_draft_prep.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from oddsfantasy import draft_prep
+from oddsfantasy.weekly_windows import earliest_future_week_start
 
 FAKE_SLEEPER_PLAYERS = {
     "1": {"full_name": "Josh Allen", "position": "QB", "team": "BUF"},
@@ -84,8 +85,17 @@ class PlanWeekForDraftTest(unittest.TestCase):
     def test_builds_plan_for_week1_and_week2_separately(self, mock_get_players, mock_get_events):
         mock_get_players.return_value = FAKE_SLEEPER_PLAYERS
         now = dt.datetime.utcnow()
-        week1_ts = _ts(now + dt.timedelta(days=10))
-        week2_ts = _ts(now + dt.timedelta(days=17))
+        # Anchor the fixture to the Thu-Mon slate the planner will actually
+        # resolve, rather than to a bare "now + N days" offset. A fixed offset
+        # makes this test depend on the weekday it runs on: two days in seven
+        # it lands on a Tue/Wed, which is outside any Thu-Mon window, and
+        # plan_week_for_draft correctly returns nothing. Real NFL games never
+        # fall there, so the fixture -- not the planner -- was wrong.
+        week1_start = earliest_future_week_start(
+            [{"commence_time": _ts(now + dt.timedelta(days=10))}], now
+        )
+        week1_ts = _ts(week1_start + dt.timedelta(days=1))
+        week2_ts = _ts(week1_start + dt.timedelta(days=8))
         mock_get_events.return_value = [
             {
                 "id": "game-week1",


### PR DESCRIPTION
## What

`tests/test_draft_prep.py::PlanWeekForDraftTest::test_builds_plan_for_week1_and_week2_separately` fails depending on what weekday it runs on. It is **red on `main` right now**, so it blocks CI for any change — including docs-only ones.

## Root cause

The test built its fixture events at a fixed offset from the real clock:

```python
now = dt.datetime.utcnow()
week1_ts = _ts(now + dt.timedelta(days=10))
week2_ts = _ts(now + dt.timedelta(days=17))
```

Draft week windows run Thursday 00:00 → Monday 23:59:59 (`_resolve_draft_week_window`, anchored by `earliest_future_week_start` → `_prev_weekday(..., 3)`). A fixed `+10 days` offset lands on a different weekday depending on when the suite runs, and roughly two days in seven it puts the week-1 game on a **Tuesday or Wednesday** — outside any Thu–Mon window. `plan_week_for_draft` then correctly returns `{}` and the assertion fails.

Today is a Saturday, so `now + 10 days` is a Tuesday:

```
now       : 2026-08-22 Saturday
week1 game: 2026-09-01 Tuesday      <- outside the window
window    : 2026-08-27 Thu -> 2026-08-31 Mon 23:59:59
```

Real NFL games never fall on those days, so the **fixture was wrong, not the planner**. No production code is touched by this PR.

## Fix

Anchor the fixture to the same Thursday the planner itself resolves, then place the games on the Friday of week 1 and week 2:

```python
week1_start = earliest_future_week_start(
    [{"commence_time": _ts(now + dt.timedelta(days=10))}], now
)
week1_ts = _ts(week1_start + dt.timedelta(days=1))
week2_ts = _ts(week1_start + dt.timedelta(days=8))
```

This keeps the test's intent (week 1 and week 2 events are filtered into separate plans) while making it independent of the weekday it runs on. The sibling tests in the same file already pin `now` explicitly; this one was the outlier in using the live clock.

## Verification

- `python -m pytest tests/` — **58 passed** (was 1 failed / 57 passed on `main`)
- `ruff check .` — all checks passed
- `ruff format --check .` — 23 files already formatted
- `python -m compileall oddsfantasy tests` — clean
- Simulated the fixture against all seven possible weekdays for "today" — the week-1 game lands in window 1 and out of window 2, and the week-2 game vice versa, in every case.

## Notes

Per CONTRIBUTING this targets its feature branch, not `main`. E1 verification is not meaningful here — the change is test-only and does not alter any runtime path.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CG2XichqBTWDT6BzPXU65)_