### PR TITLE
Link the methodology spec into the docs contract and correct stale claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,17 @@ systematically overstates every event. `predicted_stats.implied_probability`
 converts American odds to a probability, and `aggregator.py` de-vigs per book
 when both sides of a market are present, normalising over/under to sum to 1.
 
-De-vig **per book, then average across books** — not the other way around. Books
-carry different margins, so averaging raw implied probabilities across books
-blends their vig into the result in a way you can't back out afterwards. There
-is a known wart here: `aggregator.py` averages the per-book de-vigged
-probabilities, and an average of averages isn't strictly correct when books have
-different numbers of markets. It's fine for a first pass and hasn't been worth
-fixing.
+De-vig **per book, then combine across books** — not the other way around. Books
+carry different margins, so combining raw implied probabilities across books
+blends their vig into the result in a way you can't back out afterwards.
+
+The combine step is a **median** of the per-book de-vigged probabilities
+(`aggregator.py`), not a mean. The median is the robustness: a single stale book
+that hasn't repriced for an injury or weather can't drag the consensus, and no
+per-book weights or outlier rules are needed on top of it. Note the residual
+naming debt — `MarketSummary` still calls the fields `avg_over_prob`,
+`avg_under_prob` and `avg_threshold` from when this was a mean, and the values
+they hold are medians.
 
 ### One line is not a distribution, so pick a shape
 
@@ -61,6 +65,26 @@ understates ceilings for exactly the boom/bust receivers where the ceiling is
 the whole reason you'd start them.
 
 Floor/mid/ceiling are the 15th/50th/85th percentiles, not min/expected/max.
+
+### As-built here, target in `docs/fantasy-projection-methodology.md`
+
+This section describes **what the code does today**. `docs/fantasy-projection-methodology.md`
+describes the **target method** — derived from first principles, independent of
+any code, and explicitly "the reference the implementation is measured against."
+The two are meant to differ; a reader hitting one without the other is the
+problem, so the current gaps are worth naming:
+
+| | As built (this file) | Target (methodology doc) |
+| --- | --- | --- |
+| CDF anchors | one (threshold, probability) pair per market; `*_alternate` ladders skipped for quota | the full alternate ladder, interpolated (PCHIP) between anchors |
+| Count stats | Poisson fit to the single CDF point | difference the cumulative lines (`§4`); Poisson/NB only where lines are sparse |
+| Floor / ceiling | 15th / 85th percentiles | 10th / 90th (`§5`) |
+| Bonus thresholds | yardage thresholds hardcoded in `odds_details.py`; only the point *amounts* come from Sleeper | thresholds and amounts both configuration (`§2.4`) |
+| Aggregation | per-stat only; no player-level joint model | player-level sum, with cross-stat correlation an open question (`§2.5`) |
+
+Cross-book median de-vigging is the one place they already agree. Closing any of
+the rest is a code change, not a doc change — the doc is the spec, so update it
+first if the target itself should move.
 
 ### Alternate lines are deliberately not used by default
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,16 +85,17 @@ image tag from `github.ref`, then calls three stages in sequence:
 
 **A red check is a hard stop**, not a "merge anyway and fix later."
 
-> **Planned, not built.** Today the repo has `test.yml` (pytest on PRs and pushes
-> to `main`) and `build.yml` (pushes `:latest` on `main`). The pipeline above is
-> the target and lands as a separate change, because **files under
-> `.github/workflows/` must be added and edited by a human** — GitHub rejects
-> automation tokens without an explicit `workflow` scope.
+> **Built.** `ci.yml`, `lint.yml`, `test.yml` and `publish.yml` are all in place
+> and `build.yml` is gone. Keep in mind that **files under `.github/workflows/`
+> must be added and edited by a human** — GitHub rejects automation tokens
+> without an explicit `workflow` scope — so a change that needs a workflow edit
+> cannot be completed by an assistant end to end.
 
 ## Documentation
 
-Three files, three jobs — keeping them separate is what stops the README from
-drifting into describing an app that stopped being the real entrypoint.
+Three files plus `docs/`, each with one job — keeping them separate is what stops
+the README from drifting into describing an app that stopped being the real
+entrypoint.
 
 - **`README.md`** — concise, external perspective: how to use it, how to test it.
   Not inner workings. Updated in the same commit as any change that alters how
@@ -103,6 +104,12 @@ drifting into describing an app that stopped being the real entrypoint.
   details. Why the model is shaped this way, why the quota rules exist, what was
   tried and rejected. No length limit. *(Written during the cleanup pass.)*
 - **`CONTRIBUTING.md`** — this file. Process only. Rationale goes in `AGENTS.md`.
+- **`docs/*.md`** — long-form specs that stand on their own and outlive any one
+  implementation, e.g. `docs/fantasy-projection-methodology.md`. A spec says what
+  the model *should* do, argued independently of the code; `AGENTS.md` says what
+  the code *does* and where it diverges. Every file here must be linked from
+  `AGENTS.md` — an unreferenced spec is how two divergent accounts of the same
+  model start.
 
 ## Keeping the repo from rotting again
 
@@ -128,9 +135,9 @@ default outcome when a solo project has no rule against it. So:
 ## Odds API quota awareness
 
 The quota is a metered, shared resource, not a rate limit to retry past.
-`refactored/ratelimit.py` tracks it from response headers; `refactored/odds_client.py`
+`oddsfantasy/ratelimit.py` tracks it from response headers; `oddsfantasy/odds_client.py`
 TTL-caches responses (`ODDS_TTL`, default 12h). Any feature fetching odds for
-**more than the caller's own roster** (the way `refactored/draft_prep.py`'s draft
+**more than the caller's own roster** (the way `oddsfantasy/draft_prep.py`'s draft
 board does) costs meaningfully more than the weekly lineup flow, so:
 
 - Default to a conservative market set; skip `_alternate` markets without a

--- a/docs/fantasy-projection-methodology.md
+++ b/docs/fantasy-projection-methodology.md
@@ -4,6 +4,13 @@
 
 **Status:** v0.9 — living document. Market-translation-only and scoring-as-configuration principles established; method is ruleset-agnostic and PPR-ready; rushing/receiving/passing yards, receptions, touchdowns, and interceptions done; player aggregation and DEF / K next.
 
+**Relationship to `AGENTS.md`.** This document is the *target*: what the model
+should do, argued from the market up. `AGENTS.md` records what the code does
+*today* and why, including where it falls short of this document. When the two
+disagree, this one describes the destination and `AGENTS.md` describes the
+current position — see its "As-built here, target in
+`docs/fantasy-projection-methodology.md`" table for the live gap list.
+
 **What the model produces.** A full fantasy-points *probability distribution* per player — the whole curve, not just a mean — because every downstream use (floor/ceiling, matchup leverage, lineup win-probability) needs the distribution. The method is **ruleset-agnostic**: scoring rules, PPR, bonuses, and league format are all configuration, and any specific league is just one instance (this project's is summarized in §2.4 and used in the worked examples).
 
 **This project's goal (a usage lens, not part of the method).** The league this project runs in pays only for a top-3 finish — a tournament objective — so when *using* the curve (§5) we lean especially on the right tail (ceiling). This shapes how the distribution is read, not how it is built.


### PR DESCRIPTION
## Why

`docs/fantasy-projection-methodology.md` landed on `main` as an **orphan**: nothing in the repo references it, and CONTRIBUTING's Documentation section names only three files, so `docs/` isn't a sanctioned location at all. A reader has no path to the spec and no way to know how it relates to `AGENTS.md` — which covers the same subject and, in places, contradicts it without saying so. That is the divergent-accounts rot the contract exists to prevent, applied to docs instead of code.

## Changes

**Sanction `docs/` and link it (CONTRIBUTING.md)** — adds `docs/*.md` to the Documentation section with a stated job: standalone specs that argue what the model *should* do, independent of the code, where `AGENTS.md` records what it *does*. Every file there must be linked from `AGENTS.md`.

**As-built vs target table (AGENTS.md)** — a short subsection under "Turning odds into a range" pointing at the spec and naming the real gaps:

| | As built | Target (spec) |
| --- | --- | --- |
| CDF anchors | one (threshold, probability) pair; `*_alternate` skipped for quota | full ladder, PCHIP between anchors |
| Count stats | Poisson fit to the single point | difference the cumulative lines (§4) |
| Floor / ceiling | 15th / 85th percentiles | 10th / 90th (§5) |
| Bonus thresholds | hardcoded in `odds_details.py`; only amounts from Sleeper | thresholds and amounts both config (§2.4) |
| Aggregation | per-stat only | player-level sum, correlation open (§2.5) |

**Pointer back (methodology doc)** — one paragraph noting `AGENTS.md` is the record of what's actually built. The doc's own content is otherwise untouched.

## Stale claims corrected, both verified against the code

**`AGENTS.md` described the wrong combine step.** It said `aggregator.py` *averages* the per-book de-vigged probabilities and called the resulting "average of averages" a known wart. The code uses `statistics.median` (`aggregator.py:193-195`), which is what the spec calls for (§2.2, Locked) — so the two already agree and the wart doesn't exist. The naming debt is real, though: `MarketSummary` still exposes `avg_over_prob` / `avg_under_prob` / `avg_threshold` holding medians. Noted in `AGENTS.md` rather than renamed — that's a code change for its own PR.

**Dead package paths.** The quota section pointed at `refactored/ratelimit.py`, `refactored/odds_client.py` and `refactored/draft_prep.py`; that package is `oddsfantasy/` now. Confirmed all three exist under the new name. The historical mention of `refactored/` in the repo-rot section is left alone — it describes the past correctly.

**CI described as unbuilt.** The "Planned, not built" note said the repo only has `test.yml` and `build.yml`. `ci.yml`, `lint.yml`, `test.yml` and `publish.yml` all exist and `build.yml` is gone. The human-must-edit-workflows constraint is kept, since it still binds.

## Verification

- `ruff check .` — all checks passed
- `ruff format --check .` — 23 files already formatted
- `python -m compileall oddsfantasy tests` — clean
- `python -m pytest tests/` — inherits the pre-existing `test_draft_prep` failure from this branch's base; fixed by #30, which merges into the same feature branch first. Green once that lands.

Docs only — no code or test changes. E1 verification is not meaningful for a docs-only change.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CG2XichqBTWDT6BzPXU65)_