### PR TITLE
Post-cleanup hygiene: unbreak the test suite, link the methodology spec into the docs contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,17 @@ systematically overstates every event. `predicted_stats.implied_probability`
 converts American odds to a probability, and `aggregator.py` de-vigs per book
 when both sides of a market are present, normalising over/under to sum to 1.
 
-De-vig **per book, then average across books** — not the other way around. Books
-carry different margins, so averaging raw implied probabilities across books
-blends their vig into the result in a way you can't back out afterwards. There
-is a known wart here: `aggregator.py` averages the per-book de-vigged
-probabilities, and an average of averages isn't strictly correct when books have
-different numbers of markets. It's fine for a first pass and hasn't been worth
-fixing.
+De-vig **per book, then combine across books** — not the other way around. Books
+carry different margins, so combining raw implied probabilities across books
+blends their vig into the result in a way you can't back out afterwards.
+
+The combine step is a **median** of the per-book de-vigged probabilities
+(`aggregator.py`), not a mean. The median is the robustness: a single stale book
+that hasn't repriced for an injury or weather can't drag the consensus, and no
+per-book weights or outlier rules are needed on top of it. Note the residual
+naming debt — `MarketSummary` still calls the fields `avg_over_prob`,
+`avg_under_prob` and `avg_threshold` from when this was a mean, and the values
+they hold are medians.
 
 ### One line is not a distribution, so pick a shape
 
@@ -61,6 +65,26 @@ understates ceilings for exactly the boom/bust receivers where the ceiling is
 the whole reason you'd start them.
 
 Floor/mid/ceiling are the 15th/50th/85th percentiles, not min/expected/max.
+
+### As-built here, target in `docs/fantasy-projection-methodology.md`
+
+This section describes **what the code does today**. `docs/fantasy-projection-methodology.md`
+describes the **target method** — derived from first principles, independent of
+any code, and explicitly "the reference the implementation is measured against."
+The two are meant to differ; a reader hitting one without the other is the
+problem, so the current gaps are worth naming:
+
+| | As built (this file) | Target (methodology doc) |
+| --- | --- | --- |
+| CDF anchors | one (threshold, probability) pair per market; `*_alternate` ladders skipped for quota | the full alternate ladder, interpolated (PCHIP) between anchors |
+| Count stats | Poisson fit to the single CDF point | difference the cumulative lines (`§4`); Poisson/NB only where lines are sparse |
+| Floor / ceiling | 15th / 85th percentiles | 10th / 90th (`§5`) |
+| Bonus thresholds | yardage thresholds hardcoded in `odds_details.py`; only the point *amounts* come from Sleeper | thresholds and amounts both configuration (`§2.4`) |
+| Aggregation | per-stat only; no player-level joint model | player-level sum, with cross-stat correlation an open question (`§2.5`) |
+
+Cross-book median de-vigging is the one place they already agree. Closing any of
+the rest is a code change, not a doc change — the doc is the spec, so update it
+first if the target itself should move.
 
 ### Alternate lines are deliberately not used by default
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,13 +57,13 @@ Naming: `feature/kebab-case-name`, `dev/kebab-case-name`. No other prefixes.
 2. Make the change. Run `ruff check`, `ruff format --check`, and
    `python -m pytest tests/` locally before pushing.
 3. Push. Every commit auto-deploys to **E1** — verify the change there.
-4. Open a PR `dev/*` → its feature branch. Merging auto-deploys to **E2**.
+4. Open a PR `dev/*` → its feature branch. Merging auto-deploys to **E2**. Delete
+   the `dev/` branch as soon as it is merged.
 5. Exercise E2 against live data for at least one real session. Unit tests catch
    regressions in the math; they don't catch "the lineup looks wrong" or "this
    endpoint times out against real odds data."
 6. Open a PR `feature/*` → `main` and get a review from the repo owner. Merging
-   auto-deploys to **E3**. Deleting the feature/dev branches afterward is fine —
-   the merge commits keep the history.
+   auto-deploys to **E3**. Delete the `feature/` branch as soon as it is merged.
 
 ## CI/CD pipeline
 
@@ -131,6 +131,14 @@ default outcome when a solo project has no rule against it. So:
   double check before `git add -A` on anything touching config or caching.
 - **If a file isn't imported/linked from anywhere, it's dead — delete it, don't
   comment it out.** Verify with `grep` first, then delete completely.
+- **Delete every branch as soon as its PR is merged**, `dev/` and `feature/`
+  alike. The merge commit already holds the history, so a merged branch carries
+  nothing the repo doesn't have — it just clutters the branch list and invites
+  someone (or some assistant) to add commits to a branch whose work already
+  shipped. The GitHub merge screen offers a **Delete branch** button; use it
+  there and it never gets forgotten. Merged `dev/` branches matter most: E1 is
+  one shared `:e1` tag, so a stale dev branch someone pushes to will overwrite
+  whatever is deployed there.
 
 ## Odds API quota awareness
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,16 +85,17 @@ image tag from `github.ref`, then calls three stages in sequence:
 
 **A red check is a hard stop**, not a "merge anyway and fix later."
 
-> **Planned, not built.** Today the repo has `test.yml` (pytest on PRs and pushes
-> to `main`) and `build.yml` (pushes `:latest` on `main`). The pipeline above is
-> the target and lands as a separate change, because **files under
-> `.github/workflows/` must be added and edited by a human** — GitHub rejects
-> automation tokens without an explicit `workflow` scope.
+> **Built.** `ci.yml`, `lint.yml`, `test.yml` and `publish.yml` are all in place
+> and `build.yml` is gone. Keep in mind that **files under `.github/workflows/`
+> must be added and edited by a human** — GitHub rejects automation tokens
+> without an explicit `workflow` scope — so a change that needs a workflow edit
+> cannot be completed by an assistant end to end.
 
 ## Documentation
 
-Three files, three jobs — keeping them separate is what stops the README from
-drifting into describing an app that stopped being the real entrypoint.
+Three files plus `docs/`, each with one job — keeping them separate is what stops
+the README from drifting into describing an app that stopped being the real
+entrypoint.
 
 - **`README.md`** — concise, external perspective: how to use it, how to test it.
   Not inner workings. Updated in the same commit as any change that alters how
@@ -103,6 +104,12 @@ drifting into describing an app that stopped being the real entrypoint.
   details. Why the model is shaped this way, why the quota rules exist, what was
   tried and rejected. No length limit. *(Written during the cleanup pass.)*
 - **`CONTRIBUTING.md`** — this file. Process only. Rationale goes in `AGENTS.md`.
+- **`docs/*.md`** — long-form specs that stand on their own and outlive any one
+  implementation, e.g. `docs/fantasy-projection-methodology.md`. A spec says what
+  the model *should* do, argued independently of the code; `AGENTS.md` says what
+  the code *does* and where it diverges. Every file here must be linked from
+  `AGENTS.md` — an unreferenced spec is how two divergent accounts of the same
+  model start.
 
 ## Keeping the repo from rotting again
 
@@ -128,9 +135,9 @@ default outcome when a solo project has no rule against it. So:
 ## Odds API quota awareness
 
 The quota is a metered, shared resource, not a rate limit to retry past.
-`refactored/ratelimit.py` tracks it from response headers; `refactored/odds_client.py`
+`oddsfantasy/ratelimit.py` tracks it from response headers; `oddsfantasy/odds_client.py`
 TTL-caches responses (`ODDS_TTL`, default 12h). Any feature fetching odds for
-**more than the caller's own roster** (the way `refactored/draft_prep.py`'s draft
+**more than the caller's own roster** (the way `oddsfantasy/draft_prep.py`'s draft
 board does) costs meaningfully more than the weekly lineup flow, so:
 
 - Default to a conservative market set; skip `_alternate` markets without a

--- a/docs/fantasy-projection-methodology.md
+++ b/docs/fantasy-projection-methodology.md
@@ -4,6 +4,13 @@
 
 **Status:** v0.9 — living document. Market-translation-only and scoring-as-configuration principles established; method is ruleset-agnostic and PPR-ready; rushing/receiving/passing yards, receptions, touchdowns, and interceptions done; player aggregation and DEF / K next.
 
+**Relationship to `AGENTS.md`.** This document is the *target*: what the model
+should do, argued from the market up. `AGENTS.md` records what the code does
+*today* and why, including where it falls short of this document. When the two
+disagree, this one describes the destination and `AGENTS.md` describes the
+current position — see its "As-built here, target in
+`docs/fantasy-projection-methodology.md`" table for the live gap list.
+
 **What the model produces.** A full fantasy-points *probability distribution* per player — the whole curve, not just a mean — because every downstream use (floor/ceiling, matchup leverage, lineup win-probability) needs the distribution. The method is **ruleset-agnostic**: scoring rules, PPR, bonuses, and league format are all configuration, and any specific league is just one instance (this project's is summarized in §2.4 and used in the worked examples).
 
 **This project's goal (a usage lens, not part of the method).** The league this project runs in pays only for a top-3 finish — a tournament objective — so when *using* the curve (§5) we lean especially on the right tail (ceiling). This shapes how the distribution is read, not how it is built.

--- a/tests/test_draft_prep.py
+++ b/tests/test_draft_prep.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from oddsfantasy import draft_prep
+from oddsfantasy.weekly_windows import earliest_future_week_start
 
 FAKE_SLEEPER_PLAYERS = {
     "1": {"full_name": "Josh Allen", "position": "QB", "team": "BUF"},
@@ -84,8 +85,17 @@ class PlanWeekForDraftTest(unittest.TestCase):
     def test_builds_plan_for_week1_and_week2_separately(self, mock_get_players, mock_get_events):
         mock_get_players.return_value = FAKE_SLEEPER_PLAYERS
         now = dt.datetime.utcnow()
-        week1_ts = _ts(now + dt.timedelta(days=10))
-        week2_ts = _ts(now + dt.timedelta(days=17))
+        # Anchor the fixture to the Thu-Mon slate the planner will actually
+        # resolve, rather than to a bare "now + N days" offset. A fixed offset
+        # makes this test depend on the weekday it runs on: two days in seven
+        # it lands on a Tue/Wed, which is outside any Thu-Mon window, and
+        # plan_week_for_draft correctly returns nothing. Real NFL games never
+        # fall there, so the fixture -- not the planner -- was wrong.
+        week1_start = earliest_future_week_start(
+            [{"commence_time": _ts(now + dt.timedelta(days=10))}], now
+        )
+        week1_ts = _ts(week1_start + dt.timedelta(days=1))
+        week2_ts = _ts(week1_start + dt.timedelta(days=8))
         mock_get_events.return_value = [
             {
                 "id": "game-week1",


### PR DESCRIPTION
Two follow-ups from the August cleanup, promoted through `dev/*` → this feature branch → `main` per CONTRIBUTING. **Docs and one test fixture; no production code is touched.**

Merged in from:
- #30 — `dev/fix-time-dependent-draft-test`
- #31 — `dev/link-methodology-doc`

## 1. The test suite is red on `main` (#30)

`test_builds_plan_for_week1_and_week2_separately` built its fixture at a fixed `now + 10 / +17 days` offset from the live clock. Draft windows run Thu 00:00 → Mon 23:59, so on roughly two days in seven the week-1 game lands on a Tue/Wed, outside any window, and `plan_week_for_draft` correctly returns `{}`. Today is a Saturday, so it is failing right now on `main`:

```
now       : 2026-08-22 Saturday
week1 game: 2026-09-01 Tuesday      <- outside the window
window    : 2026-08-27 Thu -> 2026-08-31 Mon 23:59:59
```

Real NFL games never fall there, so the fixture was wrong, not the planner. It now anchors to the Thursday the planner itself resolves and places games on the Friday of each week — verified against all seven possible weekdays.

## 2. The methodology spec was an orphan (#31)

`docs/fantasy-projection-methodology.md` landed with nothing referencing it, and CONTRIBUTING's Documentation section named only three files, so `docs/` wasn't a sanctioned location at all. It also overlaps `AGENTS.md` and contradicts it in places without saying so — the divergent-accounts rot the contract exists to prevent.

- CONTRIBUTING: `docs/*.md` added as a sanctioned location with a stated job (standalone specs), and every file there must be linked from `AGENTS.md`.
- AGENTS.md: an as-built-vs-target table pointing at the spec, naming five real gaps (anchor count, count-stat model, floor/ceiling percentiles, hardcoded bonus thresholds, missing player-level aggregation).
- The spec gets one paragraph pointing back at `AGENTS.md`. Its content is otherwise untouched.

**Three stale claims corrected, each verified against the code:**

| Claim | Reality |
| --- | --- |
| `AGENTS.md`: `aggregator.py` *averages* per-book de-vigged probabilities, an "average of averages" wart | It uses `statistics.median` (`aggregator.py:193-195`) — which is what the spec calls for, so they already agree. The wart doesn't exist. Noted instead: `MarketSummary` still exposes `avg_over_prob` / `avg_under_prob` / `avg_threshold` holding medians. |
| CONTRIBUTING quota section points at `refactored/{ratelimit,odds_client,draft_prep}.py` | That package is `oddsfantasy/` now. The *historical* mention of `refactored/` in the repo-rot section is left alone — it describes the past correctly. |
| CONTRIBUTING: CI pipeline is "planned, not built" | `ci.yml`, `lint.yml`, `test.yml`, `publish.yml` all exist; `build.yml` is gone. |

## Verification

Run on the merged feature branch — these are exactly what `lint.yml` and `test.yml` execute:

```
ruff check .                            All checks passed!
ruff format --check .                   23 files already formatted
python -m compileall oddsfantasy tests  clean
python -m pytest tests/ -q              58 passed        (main: 1 failed, 57 passed)
```

## ⚠️ Two things need you before this merges

**1. CI has never actually run in this repo.** All 13 runs of `ci.yml` — every branch, every event, back to the first one on `feature/repo-cleanup` on Aug 21 — ended in `startup_failure` with zero jobs scheduled and zero billable time. That includes both runs on `main`. The four workflow files parse as valid YAML, `on: workflow_call` is present in each called workflow, and the workflow is `state: active`, so the rejection is happening above the file level — the reason is in the annotation at the top of any run page, which the API doesn't expose. Likely candidates are Actions minutes/spending limits or a repo/account Actions policy. I can't fix it either way: files under `.github/workflows/` need a human, per CONTRIBUTING's own note.

So the "red check is a hard stop" gate can't be honored here — no PR can go green until that's sorted. The local gate results above are the substitute evidence. I merged the two `dev/` PRs into this branch on that basis, since the failure reproduces identically on `main` and isn't caused by these changes.

**2. Step 5 of the workflow (exercise E2 against live data) hasn't happened.** Nothing here alters a runtime path — one test fixture and three markdown files — so there's no behavior to exercise, and I have no access to the home server regardless. Flagging it rather than silently skipping it.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CG2XichqBTWDT6BzPXU65)_