### PR TITLE
Correct the claim that workflow files must be edited by a human

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,16 @@ image tag from `github.ref`, then calls three stages in sequence:
 **A red check is a hard stop**, not a "merge anyway and fix later."
 
 > **Built.** `ci.yml`, `lint.yml`, `test.yml` and `publish.yml` are all in place
-> and `build.yml` is gone. Keep in mind that **files under `.github/workflows/`
-> must be added and edited by a human** — GitHub rejects automation tokens
-> without an explicit `workflow` scope — so a change that needs a workflow edit
-> cannot be completed by an assistant end to end.
+> and `build.yml` is gone.
+
+**Editing workflow files is not human-only.** This file used to claim that
+anything under `.github/workflows/` had to be added or edited by a person,
+because GitHub rejects automation tokens lacking an explicit `workflow` scope.
+That rejection is real but conditional — it depends entirely on the credential
+in use. A Claude Code session pushed five workflow files to this repo on
+2026-08-22 without hitting it. So don't route a workflow change around an
+assistant on principle; try the push, and only fall back to doing it by hand
+if the remote actually refuses it.
 
 ## Documentation
 


### PR DESCRIPTION
## What

CONTRIBUTING stated that anything under `.github/workflows/` had to be added or edited by a person, because GitHub rejects automation tokens without an explicit `workflow` scope.

The rejection is real, but it's **conditional on the credential**, not on the file path. While diagnosing why `ci.yml` had never run, a Claude Code session pushed five workflow files to this repo today without hitting it.

Replaced the blanket rule with what's actually true: try the push, fall back to doing it by hand only if the remote refuses. The stale "planned, not built" framing around it was already fixed in #32; this trims what's left of that blockquote to just the status line.

## Verification

```
ruff check .              All checks passed!
ruff format --check .     clean
python -m compileall      clean
python -m pytest tests/   58 passed
```

Docs only — no code, no workflow files touched.

## Note

Merging this publishes `:e2` and is the first real E2 deploy, so it doubles as the E2 half of the pipeline test.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CG2XichqBTWDT6BzPXU65)_