### PR TITLE
Add the Test service to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 data/
+data-test/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+  # Production. Tracks :latest, which CI publishes on every merge to main.
   odds-fantasy:
     image: ghcr.io/wesnicol2/odds-fantasy:latest
     env_file:
@@ -7,4 +8,20 @@ services:
       - "8000:8000"
     volumes:
       - ./data:/app/data
+    restart: unless-stopped
+
+  # Test. Tracks :test, which CI publishes on every merge into a feature
+  # branch. Deliberately given its own data volume rather than sharing
+  # ./data: that directory holds the cached-odds store, and letting test
+  # traffic write into production's cache would corrupt it. The cost of
+  # separating them is that each environment spends its own Odds API quota,
+  # which is the right trade but worth knowing before exercising Test hard.
+  odds-fantasy-test:
+    image: ghcr.io/wesnicol2/odds-fantasy:test
+    env_file:
+      - .env
+    ports:
+      - "8001:8000"
+    volumes:
+      - ./data-test:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## What

The compose file described only production, so it under-described the two-environment model the rest of the docs now specify. Adds an `odds-fantasy-test` service tracking `:test` alongside the existing `odds-fantasy` on `:latest`.

## Decisions worth reviewing

**Test gets its own `./data-test` volume rather than sharing `./data`.** That directory holds the cached-odds store, so pointing both environments at it would let test traffic corrupt production's cache. The cost is that each environment spends its own Odds API quota — the right trade given the quota section in CONTRIBUTING, but not obvious from reading the file, so it's written in as a comment.

**`./data-test` needed a `.gitignore` entry.** `.gitignore` had `data/`, which does **not** match `data-test/` — without this the test cache would have been committable. Added directly under `data/`.

**Host ports follow this file's convention, not the Unraid deployment's.** Production already maps `8000:8000` here, so Test takes `8001:8000`. The compose file uses relative volume paths and its own ports; the Unraid containers use absolute appdata paths and their own ports, and are configured on the server rather than from this file. If you'd rather compose mirror the server exactly, tell me the port and path that box is using and I'll match them.

**Both services read the same `.env`.** Same Odds API account, so the same `API_KEY` is correct. Split it into `.env.test` if you ever want Test on a separate key or quota.

## Verification

```
docker-compose.yml        parses; services: odds-fantasy, odds-fantasy-test
ruff check .              All checks passed!
ruff format --check .     clean
python -m pytest tests/   58 passed
```

Config only — no application code.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CG2XichqBTWDT6BzPXU65)_