### PR TITLE
Match compose host ports to the actual deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ and reads `.env`:
 docker compose up -d
 ```
 
+That brings up **two** services: `odds-fantasy` (production, `:latest`, port
+8001) and `odds-fantasy-test` (test, `:test`, port 8003, its own `./data-test`
+volume). For just the one, name it: `docker compose up -d odds-fantasy`. The
+two environments are described in [CONTRIBUTING.md](CONTRIBUTING.md).
+
 Mount `/app/data` somewhere persistent — the odds cache and Sleeper player
 metadata live there, and losing it means re-spending API quota.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file:
       - .env
     ports:
-      - "8000:8000"
+      - "8001:8000"
     volumes:
       - ./data:/app/data
     restart: unless-stopped
@@ -21,7 +21,7 @@ services:
     env_file:
       - .env
     ports:
-      - "8001:8000"
+      - "8003:8000"
     volumes:
       - ./data-test:/app/data
     restart: unless-stopped


### PR DESCRIPTION
Addresses the review comment on #36: Test is reached on **8003** and production on **8001**.

| Service | Was | Now |
| --- | --- | --- |
| `odds-fantasy` | `8000:8000` | `8001:8000` |
| `odds-fantasy-test` | `8001:8000` | `8003:8000` |

Worth noting the old values weren't just cosmetically off — following the compose file gave you production on the wrong port *and* Test sitting on production's. Production's `8001` also matches what the README's `docker run` example and its "then open `http://<host>:8001/`" line already said, so compose was the odd one out rather than the source of truth.

## README

`docker compose up -d` now starts two containers, which the README didn't say — it still described the file as the one that "mounts `./data` and reads `.env`". Added a short note covering both services, their ports, the separate test volume, and how to bring up only production (`docker compose up -d odds-fantasy`), pointing at CONTRIBUTING for the environment model.

That edit is the README tier of the doc policy in #38 doing its job on its first outing: the change contradicted the README, so the README moved in the same commit.

## Verification

```
docker-compose.yml   {'odds-fantasy': ['8001:8000'], 'odds-fantasy-test': ['8003:8000']}
ruff check .         All checks passed!
ruff format --check  clean
pytest tests/        58 passed
```

Config and docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CG2XichqBTWDT6BzPXU65)_